### PR TITLE
exclude_shared_token_cache_credential

### DIFF
--- a/proteus/connectors/beast/_auth.py
+++ b/proteus/connectors/beast/_auth.py
@@ -24,7 +24,7 @@ class BeastAuth(AuthBase):
 
         :return:
         """
-        credential = DefaultAzureCredential()
+        credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
         token: str = credential.get_token("https://management.core.windows.net/.default").token
         self.cache.append((token, datetime.utcnow()))
 


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
 - Awesome new feature
 - And another awesome new feature

Additional changes:
- Refactored `AwesomeClass`
- Removed deprecated `AnotherClass` and `get_awesomeness` from `AwesomeClass`

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
