### PR TITLE
Add a method to start a job without waiting for result

### DIFF
--- a/proteus/connectors/beast/_connector.py
+++ b/proteus/connectors/beast/_connector.py
@@ -143,7 +143,7 @@ class BeastConnector:
         :return: A JobRequest for Beast.
         """
 
-        (request_id, request_lifecycle) = self._existing_submission(submitted_tag=context['task_instance_key_str'],
+        (request_id, _) = self._existing_submission(submitted_tag=context['task_instance_key_str'],
                                                                     project=job_params.project_name)
 
         if not request_id:


### PR DESCRIPTION
## Scope

Implemented:
 - Added `start_job` method to Beast connector, so we can start a job and exit, without waiting for it to finish
 - 
## Checklist

- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
