### PR TITLE
Add utility method for stopping all streaming with a matching tag

### DIFF
--- a/proteus/connectors/arcane/_models.py
+++ b/proteus/connectors/arcane/_models.py
@@ -92,3 +92,4 @@ class StreamState(Enum):
     STOPPED = 'STOPPED'
     TERMINATING = 'TERMINATING'
     RESTARTING = 'RESTARTING'
+    FAILED = 'FAILED'


### PR DESCRIPTION
## Scope

Implemented:
 - Added `FAILED` status from API
 - Added method to stop streams in bulk using client tag.
