### PR TITLE
Make user and password not mandatory parameters

### DIFF
--- a/proteus/connectors/crystal/_connector.py
+++ b/proteus/connectors/crystal/_connector.py
@@ -25,7 +25,7 @@ class CrystalConnector:
             self.http.auth = HTTPBasicAuth(user, password)
 
     @staticmethod
-    def create_authenticated(*, base_url: str, user: Optional[str], password: Optional[str]):
+    def create_authenticated(*, base_url: str, user: Optional[str] = None, password: Optional[str] = None):
         """Creates Crystal connector with basic authentication.
         For connecting to Crystal outside the Crystal kubernetes cluster, e.g.
         from other cluster or Airflow environment.


### PR DESCRIPTION
Fixes  #82.

## Scope

Implemented:
- Added default value for username and password

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
