### PR TITLE
Optional exceptions and better redirect

### DIFF
--- a/proteus/logs/_base.py
+++ b/proteus/logs/_base.py
@@ -243,8 +243,10 @@ class ProteusLogger:
                 LogLevel.DEBUG: logger.debug
             }
 
+            log_method[log_level](log_header(state='BEGIN'))
+
             with open(tmp_file, encoding='utf-8') as output:
-                log_method[log_level](log_header(state='BEGIN'))
                 for line in output.readlines():
                     log_method[log_level](log_message(msg=line))
+
             log_method[log_level](log_header(state='END'))


### PR DESCRIPTION
Closes #100 
Closes #99

## Scope

Implemented:
 - Exceptions are now optional for warn, err and debug methods.
 - Redirect supports log level and no longer relies on `self.info` public method
 - 
## Checklist

- [x] GitHub issue exists for this change.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
