### PR TITLE
Allow with OdbcClient(...) as client syntax

### DIFF
--- a/proteus/storage/database/odbc.py
+++ b/proteus/storage/database/odbc.py
@@ -82,6 +82,7 @@ class OdbcClient(ABC):
                 driver=self._dialect.driver,
                 exception=ex
             )
+
             return None
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
Fixes an issue forcing us to write like this:
```
client  = OdbcClient(...)

with client:
   ...
```
instead of 
```
with OdbcClient(...) as odbc_client:
   ...
```