### PR TITLE
Add skip_dependencies to GitHub action for building package

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,4 +1,4 @@
-name: Crate development package
+name: Create development package
 
 on: issue_comment
 


### PR DESCRIPTION
## Scope

Add skip_dependencies parameter to poetry workflow since we do not need to install dependencies to build a wheel.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass. -- changes only in build process
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.

