### PR TITLE
Not fail on import AzureClient if proteus is installed without extra hashicorp

### DIFF
--- a/proteus/security/clients/__init__.py
+++ b/proteus/security/clients/__init__.py
@@ -8,6 +8,7 @@ try:
     from proteus.security.clients._hashicorp_vault_client import HashicorpVaultClient
 except ImportError:
     pass
+
 try:
     from proteus.security.clients._azure_client import AzureClient
 except ImportError:


### PR DESCRIPTION
Fixes #158

## Scope

Implemented:
 - Do not fail if one of optional features is not installed

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
