### PR TITLE
Add ability to import MetricsProvider from public package

### DIFF
--- a/proteus/metrics/__init__.py
+++ b/proteus/metrics/__init__.py
@@ -1,1 +1,5 @@
+"""
+ Import index.
+"""
+
 from proteus.metrics._base import MetricsProvider


### PR DESCRIPTION
In projects that use proteus, we can import only Datadog provider. `MetricsProvider` can be imported only that way: `from proteus.metrics._base import MetricsProvider`

## Scope

Implemented:
 - Add ability to import MetricsProvider interface

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
