### PR TITLE
Disable stackinfo on debug logs

### DIFF
--- a/proteus/logs/_base.py
+++ b/proteus/logs/_base.py
@@ -207,7 +207,7 @@ class ProteusLogger:
                                  template=template,
                                  tags=tags,
                                  diagnostics=diagnostics,
-                                 stack_info=True,
+                                 stack_info=False,
                                  exception=exception,
                                  metadata_fields=self.__get_metadata_fields(kwargs))
 

--- a/proteus/storage/delta_lake/_functions.py
+++ b/proteus/storage/delta_lake/_functions.py
@@ -216,10 +216,11 @@ def load_cached(  # pylint: disable=R0913
                 ConnectionAbortedError,
                 ConnectionRefusedError,
         ) as ex:
-            logger.warning(
-                'Error when reading data from cache - most likely some cache entries have been evicted. Falling back to storage.',
-                exception=ex
-            )
+            if logger:
+                logger.warning(
+                    'Error when reading data from cache - most likely some cache entries have been evicted. Falling back to storage.',
+                    exception=ex
+                )
 
     if logger:
         logger.debug(


### PR DESCRIPTION
## Scope

Implemented:
 - Remove stack trace prints for every debug log message
 - Check for logger existence in `load_cached` before firing a warning.