### PR TITLE
Fix the enigma

### DIFF
--- a/proteus/logs/handlers/datadog_api_handler.py
+++ b/proteus/logs/handlers/datadog_api_handler.py
@@ -120,8 +120,8 @@ class DataDogApiHandler(Handler):
             return self._existing_sigterm_handler(sig_num, stack_frame)
         if sig_num == signal.SIGINT and self._existing_sigint_handler is not None:
             return self._existing_sigint_handler(sig_num, stack_frame)
-            
-        return
+
+        return None
 
     def _flush(self) -> None:
         """


### PR DESCRIPTION
Fixes an issue with `self._flush` called as a signal handler causing a `TypeError`.
Fixes #226 

## Scope

Implemented:
 - Added a method to save existing handlers and attach a new one from DD log handler. Existing handlers will be called after a log flush.
 - Added a lock acquire/release between flushes

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
