### PR TITLE
Close browser window after OIDC login

### DIFF
--- a/adapta/security/clients/hashicorp_vault/oidc_client.py
+++ b/adapta/security/clients/hashicorp_vault/oidc_client.py
@@ -49,7 +49,12 @@ def _get_vault_credentials():
             self.server.token = params["code"][0]
             self.send_response(200)
             self.end_headers()
-            self.wfile.write(str.encode("<div>Authentication successful, you can close the browser now.</div>"))
+            self.wfile.write(
+                str.encode(
+                    "<script>window.close()</script><div>Authentication successful,"
+                    " you can close the browser now.</div>"
+                )
+            )
 
     server_address = ("127.0.0.1", 8250)
     httpd = HttpServ(server_address, AuthHandler)


### PR DESCRIPTION
Fixes #230.

## Scope

Implemented:
 - Automatically close browser window after OIDC login to hashicorp vault.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
