### PR TITLE
Default DD buffer size to 0

### DIFF
--- a/adapta/logs/handlers/datadog_api_handler.py
+++ b/adapta/logs/handlers/datadog_api_handler.py
@@ -49,7 +49,7 @@ class DataDogApiHandler(Handler):
     def __init__(
         self,
         *,
-        buffer_size=10,
+        buffer_size=0,
         async_handler=False,
         debug=False,
         max_flush_retry_time=30,


### PR DESCRIPTION
Prevents us from losing log messages from apps that only print 1 message/exception