### PR TITLE
Add memory limit enforcement

### DIFF
--- a/adapta/utils/README.md
+++ b/adapta/utils/README.md
@@ -2,7 +2,9 @@
 A set of utility functions that can be used in any python project.
 
 ## doze
-The doze function is used to sleep for a given amount of time (in seconds).
+The doze function is used to sleep for a given amount of time  (in seconds), in short intervals.
+
+This is useful in environments when your process needs to sleep, but respond to SIGTERM/SIGINT as soon as they are received.
 
 Example usage:
 ```python

--- a/adapta/utils/README.md
+++ b/adapta/utils/README.md
@@ -76,7 +76,7 @@ Example usage:
 ```python
 from adapta.utils import chunk_list
 
-# Split a list of numbers into 4 chunks
+# Split a list of numbers into up to 4 chunks
 numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 chunks = chunk_list(numbers, 4)
 print(chunks)
@@ -84,7 +84,7 @@ print(chunks)
 
 Output:
 ```
-[[1, 2, 3], [4, 5, 6], [7, 8], [9]]
+[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 ```
 
 ### memory_limit:

--- a/adapta/utils/README.md
+++ b/adapta/utils/README.md
@@ -1,0 +1,108 @@
+# adapta.utils
+A set of utility functions that can be used in any python project.
+
+## doze
+The doze function is used to sleep for a given amount of time (in seconds).
+
+Example usage:
+```python
+from adapta.utils import doze
+
+# Sleep for 5 seconds
+elapsed_time_ns = doze(5)
+print(f'Time elapsed (in nanoseconds): {elapsed_time_ns}')
+```
+
+Output:
+```
+Time elapsed (in nanoseconds): 5000000000
+```
+
+## session_with_retries
+The session_with_retries function is used to provision an HTTP session manager with built-in retries.
+
+Example usage:
+```python
+from adapta.utils import session_with_retries
+
+# Provision an HTTP session manager with 4 retries
+http_session = session_with_retries(retry_count=4)
+```
+
+## convert_datadog_tags
+The convert_datadog_tags function is used to convert a dictionary of tags into the Datadog tag format.
+
+Example usage:
+```python
+from adapta.utils import convert_datadog_tags
+
+# Convert a tag dictionary to Datadog tag format
+tags = {'environment': 'production', 'version': '1.0.0'}
+datadog_tags = convert_datadog_tags(tags)
+print(datadog_tags)
+```
+
+Output:
+```
+['environment:production', 'version:1.0.0']
+```
+
+## operation_time
+The operation_time context manager is used to measure the execution time of a given operation.
+
+Example usage:
+```python
+from adapta.utils import operation_time, doze
+
+# Measure execution time of the doze function
+with operation_time() as op:
+    doze(5)
+
+# Print execution time
+print(f'Time elapsed (in nanoseconds): {op.elapsed}')
+```
+
+Output:
+```
+Time elapsed (in nanoseconds): 5000000000
+```
+
+## chunk_list
+The chunk_list function is used to split a given list into a specified number of chunks.
+
+Example usage:
+```python
+from adapta.utils import chunk_list
+
+# Split a list of numbers into 4 chunks
+numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+chunks = chunk_list(numbers, 4)
+print(chunks)
+```
+
+Output:
+```
+[[1, 2, 3], [4, 5, 6], [7, 8], [9]]
+```
+
+### memory_limit:
+
+Context manager to limit the amount of memory used by a process. On context exit, the memory limit is reset to the total memory available.
+
+Parameters:
+* memory_limit_percentage (optional): Percentage of total memory to limit usage to
+* memory_limit_bytes (optional): Number of bytes to limit usage to
+
+Raises:
+* ValueError: If neither memory_limit_percentage or memory_limit_bytes is specified
+
+Example Usage:
+```python
+from adapta.utils import memory_limit
+
+with memory_limit(memory_limit_percentage=0.2):
+    # Memory limited to 20% of total available
+    # Do some stuff here
+    # if the provided limit is exceeded, MemoryError will be raised and can be caught by client code
+    pass
+```

--- a/adapta/utils/_common.py
+++ b/adapta/utils/_common.py
@@ -19,16 +19,17 @@ import math
 import os
 import sys
 
-if sys.platform != "win32":
-    import resource
 import time
 from collections import namedtuple
 from functools import partial
-from typing import List, Optional, Dict, Any, Tuple, Union
+from typing import List, Optional, Dict, Any, Tuple
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
+
+if sys.platform != "win32":
+    import resource
 
 
 def doze(seconds: int, doze_period_ms: int = 100) -> int:

--- a/adapta/utils/_common.py
+++ b/adapta/utils/_common.py
@@ -109,7 +109,7 @@ def operation_time():
 
 def chunk_list(value: List[Any], num_chunks: int) -> List[List[Any]]:
     """
-     Chunks the provided list into a specified number of chunks. This method is thread-safe.
+     Chunks the provided list into at most the specified number of chunks. This method is thread-safe.
 
     :param value: A list to chunk.
     :param num_chunks: Number of chunks to generate.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,13 +14,11 @@
 #
 import os
 import sys
-from contextlib import nullcontext as does_not_raise, AbstractContextManager
 
 import time
 from typing import List, Any, Dict, Optional
 
 import pytest
-from _pytest.python_api import RaisesContext
 
 from adapta.utils import doze, operation_time, chunk_list, memory_limit
 from adapta.utils.concurrent_task_runner import Executable, ConcurrentTaskRunner

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -178,8 +178,8 @@ def test_memory_limit_enough_memory(
 @pytest.mark.parametrize(
     "limit_bytes,limit_percentage,num_iterations",
     [
-        (512, None, 1024 * 1024),
-        (None, 1e-9, 1024 * 1024),
+        (512, None, 1024 * 1024 * 1024),
+        (None, 1e-9, 1024 * 1024 * 1024),
     ],
 )
 def test_memory_limit_error(limit_bytes: Optional[int], limit_percentage: Optional[float], num_iterations: int):


### PR DESCRIPTION
Close #254 

## Scope

Implemented:
 - Added a context manager that can limit amount of memory allowed to be used within a context block, and restores it to max afterwards. This allows user code to handle OOM as a normal exception. Linux-only functionality.

Additional changes:
- Generated some docs for `utils` module.

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Self-review.
