### PR TITLE
Pyschema

### DIFF
--- a/adapta/schema_management/README.md
+++ b/adapta/schema_management/README.md
@@ -1,0 +1,19 @@
+# Usage
+
+Creating a data model for a table "Order":
+```python
+from dataclasses import field, dataclass
+from datetime import datetime
+from typing import Optional
+
+from adapta.schema_management.schema_entity import PythonSchemaEntity
+
+@dataclass
+class Order:
+	"""Data model for entity Order
+	"""
+	created_on: Optional[datetime] = field(metadata={"DisplayName": "Created On", "Description": "Date and time when the record was created."})
+ORDER_PYTHON_SCHEMA: Order = PythonSchemaEntity(Order)
+```
+
+This allows you to reference field names directly from model class like this: `Order.created_on` will return `created_on`, which is very useful when working with dataframe libraries - removes the need to hardcode field names everywhere.

--- a/adapta/schema_management/__init__.py
+++ b/adapta/schema_management/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright (c) 2023. ECCO Sneaks & Data
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#

--- a/adapta/schema_management/schema_entity.py
+++ b/adapta/schema_management/schema_entity.py
@@ -1,0 +1,15 @@
+from dataclasses import Field
+from typing import Union, Any, List
+
+
+class PythonSchemaEntity:
+    """Entity used to override getattr to provide schema hints"""
+
+    def __init__(self, underlying_type: Union[Any, List[Field]]) -> None:
+        for field_name in underlying_type.__dataclass_fields__:
+            self.__setattr__(field_name, field_name)
+
+    # We should implement here __getattribute__ explicitly to avoid `no-member` warning from pylint
+    def __getattribute__(self, item):
+        # pylint: disable=W0235
+        return super().__getattribute__(item)

--- a/adapta/schema_management/schema_entity.py
+++ b/adapta/schema_management/schema_entity.py
@@ -1,3 +1,18 @@
+#  Copyright (c) 2023. ECCO Sneaks & Data
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 from dataclasses import Field
 from typing import Union, Any, List
 

--- a/adapta/schema_management/schema_entity.py
+++ b/adapta/schema_management/schema_entity.py
@@ -13,6 +13,10 @@
 #  limitations under the License.
 #
 
+"""
+ Wrapper for Python-based schema classes.
+"""
+
 from dataclasses import Field
 from typing import Union, Any, List
 


### PR DESCRIPTION
Moved `PythonSchemaEntity` from our yet-internal project `metadata-manager` to `adapta`.