### PR TITLE
Add data adapter

### DIFF
--- a/adapta/utils/_common.py
+++ b/adapta/utils/_common.py
@@ -159,7 +159,7 @@ def memory_limit(*, memory_limit_percentage: Optional[float] = None, memory_limi
 
 
 def adapt(
-    df: pandas.DataFrame,
+    dataframe: pandas.DataFrame,
     column_map: Dict[str, str],
     default_values: Optional[Dict[str, Union[str, int, float]]] = None,
     drop_missing: bool = True,
@@ -167,7 +167,7 @@ def adapt(
     """
     Adapts a dataframe from one nomenclature to another. Original dataframe is not mutated.
 
-    :param df: Dataframe to be adapted.
+    :param dataframe: Dataframe to be adapted.
     :param column_map: A dictionary mapping old column names to new.
     :param default_values: If a column is not present in the dataframe
     a default value mapping can be given, by mapping a column name it a value.
@@ -176,9 +176,9 @@ def adapt(
     """
     default_values = {} if default_values is None else default_values
     # Only columns in the map is adapted
-    kept_columns = list(set(column_map.keys()) & set(df.columns)) if drop_missing else df.columns
-    df = df[kept_columns].rename(columns=column_map, errors="ignore")
+    kept_columns = list(set(column_map.keys()) & set(dataframe.columns)) if drop_missing else dataframe.columns
+    dataframe = dataframe[kept_columns].rename(columns=column_map, errors="ignore")
     # Only use default values for columns not present in the dataframe
-    default_values = {k: v for (k, v) in default_values.items() if k not in df.columns}
-    df[list(default_values.keys())] = list(default_values.values())
-    return df
+    default_values = {k: v for (k, v) in default_values.items() if k not in dataframe.columns}
+    dataframe[list(default_values.keys())] = list(default_values.values())
+    return dataframe

--- a/adapta/utils/_common.py
+++ b/adapta/utils/_common.py
@@ -158,16 +158,16 @@ def memory_limit(*, memory_limit_percentage: Optional[float] = None, memory_limi
             resource.setrlimit(resource.RLIMIT_AS, (total_mem_bytes, total_mem_bytes))
 
 
-def adapt(
+def map_column_names(
     dataframe: pandas.DataFrame,
     column_map: Dict[str, str],
     default_values: Optional[Dict[str, Union[str, int, float]]] = None,
     drop_missing: bool = True,
 ) -> pandas.DataFrame:
     """
-    Adapts a dataframe from one nomenclature to another. Original dataframe is not mutated.
+    Maps a dataframe from one nomenclature to another. Original dataframe is not mutated.
 
-    :param dataframe: Dataframe to be adapted.
+    :param dataframe: Dataframe to be mapped.
     :param column_map: A dictionary mapping old column names to new.
     :param default_values: If a column is not present in the dataframe
     a default value mapping can be given, by mapping a column name it a value.
@@ -175,7 +175,7 @@ def adapt(
     dropped if the columns are present in the dataframe but not the column_map.
     """
     default_values = {} if default_values is None else default_values
-    # Only columns in the map is adapted
+    # Only columns in the map are mapped
     kept_columns = list(set(column_map.keys()) & set(dataframe.columns)) if drop_missing else dataframe.columns
     dataframe = dataframe[kept_columns].rename(columns=column_map, errors="ignore")
     # Only use default values for columns not present in the dataframe

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ from typing import List, Any, Dict, Optional
 import pandas
 import pytest
 
-from adapta.utils import doze, operation_time, chunk_list, memory_limit, adapt
+from adapta.utils import doze, operation_time, chunk_list, memory_limit, map_column_names
 from adapta.utils.concurrent_task_runner import Executable, ConcurrentTaskRunner
 
 
@@ -227,7 +227,7 @@ def test_memory_limit_error(limit_bytes: Optional[int], limit_percentage: Option
 @pytest.mark.parametrize("drop_missing", [True, False])
 def test_data_adapter(drop_missing: bool):
     """
-    Testing that generic adaption of columns work.
+    Testing that generic mapping of columns work.
     Test checks if column names are mapped, default columns
     don't overwrite existing columns and are added if a
     column is missing.
@@ -241,7 +241,7 @@ def test_data_adapter(drop_missing: bool):
 
     default_values = {"C": 9, "D": 7}
 
-    result = adapt(data, column_map, default_values, drop_missing=drop_missing)
+    result = map_column_names(data, column_map, default_values, drop_missing=drop_missing)
 
     assert len(result) == 3
     assert len(result.columns) == 2 if drop_missing else 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -235,13 +235,13 @@ def test_data_adapter(drop_missing: bool):
     :param drop_missing: If columns missing from the mapping
     dictionary should be dropped.
     """
-    df = pandas.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]})
+    data = pandas.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]})
 
     column_map = {"A": "C"}
 
     default_values = {"C": 9, "D": 7}
 
-    result = adapt(df, column_map, default_values, drop_missing=drop_missing)
+    result = adapt(data, column_map, default_values, drop_missing=drop_missing)
 
     assert len(result) == 3
     assert len(result.columns) == 2 if drop_missing else 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,9 +18,10 @@ import sys
 import time
 from typing import List, Any, Dict, Optional
 
+import pandas
 import pytest
 
-from adapta.utils import doze, operation_time, chunk_list, memory_limit
+from adapta.utils import doze, operation_time, chunk_list, memory_limit, adapt
 from adapta.utils.concurrent_task_runner import Executable, ConcurrentTaskRunner
 
 
@@ -221,3 +222,35 @@ def test_memory_limit_error(limit_bytes: Optional[int], limit_percentage: Option
     with pytest.raises(MemoryError):
         with memory_limit(memory_limit_bytes=limit_bytes, memory_limit_percentage=limit_percentage):
             test_str *= num_iterations
+
+
+@pytest.mark.parametrize("drop_missing", [True, False])
+def test_data_adapter(drop_missing: bool):
+    """
+    Testing that generic adaption of columns work.
+    Test checks if column names are mapped, default columns
+    don't overwrite existing columns and are added if a
+    column is missing.
+
+    :param drop_missing: If columns missing from the mapping
+    dictionary should be dropped.
+    """
+    df = pandas.DataFrame(data={"A": [1, 2, 3], "B": [4, 5, 6]})
+
+    column_map = {"A": "C"}
+
+    default_values = {"C": 9, "D": 7}
+
+    result = adapt(df, column_map, default_values, drop_missing=drop_missing)
+
+    assert len(result) == 3
+    assert len(result.columns) == 2 if drop_missing else 3
+
+    assert "A" not in result.columns
+    assert ("B" not in result.columns) if drop_missing else ("B" in result.columns)
+    assert "C" in result.columns
+    assert "D" in result.columns
+
+    assert (result["C"] != 7).all()
+    assert (result["C"] != 9).all()
+    assert (result["D"] == 7).all()


### PR DESCRIPTION
Adds dataframe column name adapter. Originally implemented in IAR orchestrator, but now needed somewhere else.