### PR TITLE
Support more Astra filtering capabilities

### DIFF
--- a/adapta/storage/distributed_object_store/__init__.py
+++ b/adapta/storage/distributed_object_store/__init__.py
@@ -16,4 +16,3 @@
 """
  Import index.
 """
-from adapta.storage.distributed_object_store.datastax_astra._models import *

--- a/adapta/storage/distributed_object_store/datastax_astra/README.md
+++ b/adapta/storage/distributed_object_store/datastax_astra/README.md
@@ -108,7 +108,7 @@ with AstraClient(
         client_id='client id',
         client_secret='client secret'
 ) as ac:
-    print(ac.filter_entities(TestEntityNew, [simple_filter.expression]))
+    print(ac.filter_entities(TestEntityNew, simple_filter.expression))
     
     # simple filter field == value    
     #         col_a      col_b  col_c      col_d

--- a/adapta/storage/distributed_object_store/datastax_astra/README.md
+++ b/adapta/storage/distributed_object_store/datastax_astra/README.md
@@ -55,7 +55,7 @@ with AstraClient(
   # 0  entirely
 ```
 
-## EXPERIMENTAL - Prototype for generic filtering API.
+## EXPERIMENTAL - Filtering API.
 
 You can also generate filter expressions for Astra using the new filtering API. Note that this API will be abstracted from the engine in future releases and could also be used with PyArrow expressions. 
 Right now only Astra is supported. Example usage:

--- a/adapta/storage/distributed_object_store/datastax_astra/README.md
+++ b/adapta/storage/distributed_object_store/datastax_astra/README.md
@@ -54,3 +54,74 @@ with AstraClient(
   #       col_c
   # 0  entirely
 ```
+
+## EXPERIMENTAL - Prototype for generic filtering API.
+
+You can also generate filter expressions for Astra using the new filtering API. Note that this API will be abstracted from the engine in future releases and could also be used with PyArrow expressions. 
+Right now only Astra is supported. Example usage:
+
+1. Create a table
+```cassandraql
+create table tmp.test_entity_new(
+    col_a text,
+    col_b text,
+    col_c int,
+    col_d list<int>,
+    PRIMARY KEY ( col_a, col_b )
+);
+
+insert into tmp.test_entity_new (col_a, col_b, col_c, col_d) VALUES ('something1', 'else', 123, [1, 2]);
+insert into tmp.test_entity_new (col_a, col_b, col_c, col_d) VALUES ('something1', 'different', 456, [1, 2, 3]);
+insert into tmp.test_entity_new (col_a, col_b, col_c, col_d) VALUES ('something2', 'special', 0, [0, 32, 333]);
+```
+ 2. Create field expressions and apply them
+```python
+from adapta.storage.distributed_object_store.datastax_astra import AstraField
+from adapta.storage.distributed_object_store.datastax_astra.astra_client import AstraClient
+from adapta.schema_management.schema_entity import PythonSchemaEntity
+
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class TestEntityNew:
+    col_a: str = field(metadata={
+        "is_primary_key": True,
+        "is_partition_key": True
+    })
+    col_b: str = field(metadata={
+        "is_primary_key": True,
+        "is_partition_key": False
+    })
+    col_c: int
+    col_d: List[int]
+
+SCHEMA: TestEntityNew = PythonSchemaEntity(TestEntityNew)
+simple_filter = (AstraField(SCHEMA.col_a) == "something1")
+combined_filter = (AstraField(SCHEMA.col_a) == "something1") & (AstraField(SCHEMA.col_b) == "else")
+combined_filter_with_collection = (AstraField(SCHEMA.col_a) == "something1") & (AstraField(SCHEMA.col_b).isin(['else', 'nonexistent']))
+
+with AstraClient(
+        client_name='test',
+        keyspace='tmp',
+        secure_connect_bundle_bytes="base64 bundle string",
+        client_id='client id',
+        client_secret='client secret'
+) as ac:
+    print(ac.filter_entities(TestEntityNew, [simple_filter.expression]))
+    
+    # simple filter field == value    
+    #         col_a      col_b  col_c      col_d
+    # 0  something1  different    456  [1, 2, 3]
+    # 1  something1       else    123     [1, 2]    
+    
+    print(ac.filter_entities(TestEntityNew, combined_filter.expression))
+
+    #         col_a col_b  col_c   col_d
+    # 0  something1  else    123  [1, 2]
+
+    print(ac.filter_entities(TestEntityNew, combined_filter_with_collection.expression))
+
+    #         col_a col_b  col_c   col_d
+    # 0  something1  else    123  [1, 2]
+```

--- a/adapta/storage/distributed_object_store/datastax_astra/_models.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/_models.py
@@ -2,98 +2,136 @@
  Auxiliary models for Astra client operations.
 """
 from functools import reduce
-from typing import final, List, Dict, Generic, TypeVar, Union, Any
+from typing import final, List, Dict, Generic, TypeVar, Any, Union
 
-TField = TypeVar('TField')
+TField = TypeVar("TField")  # pylint: disable=invalid-name
 
 
+@final
 class AstraFilterExpression:
+    """
+    Filter expression from combining two or more Astra fields
+    """
+
     def __init__(self, expr: List[Dict[str, Any]]):
+        """
+        Creates an AstraFilterExpression
+        """
         self._expr = expr
 
     @property
     def expression(self) -> List[Dict[str, Any]]:
+        """
+        Generated expression.
+        """
         return self._expr
 
-    def __and__(self, other: 'AstraFilterExpression') -> 'AstraFilterExpression':
-        self._expr = reduce(lambda e1, e2: e1 | e2, self._expr + other.expression)
+    def __and__(self, other: Union["AstraFilterExpression", "AstraField"]) -> "AstraFilterExpression":
+        added_expr = [other.expression] if isinstance(other, AstraField) else other.expression
+        self._expr = reduce(lambda e1, e2: e1 | e2, self._expr + added_expr)
         return self
 
-    def __or__(self, other: 'AstraFilterExpression') -> 'AstraFilterExpression':
-        self._expr = self._expr + other.expression
+    def __or__(self, other: Union["AstraFilterExpression", "AstraField"]) -> "AstraFilterExpression":
+        added_expr = [other.expression] if isinstance(other, AstraField) else other.expression
+        self._expr = self._expr + added_expr
         return self
 
 
 @final
 class AstraField(Generic[TField]):
     """
-     Represents a field in the Astra table. Semantics mimic pyarrow.
-     Based on https://docs.datastax.com/en/developer/python-driver/3.24/cqlengine/queryset/
+    Represents a field in the Astra table. Semantics mimic pyarrow.
+    Based on https://docs.datastax.com/en/developer/python-driver/3.24/cqlengine/queryset/
     """
+
     def __init__(self, field_name: str):
+        """
+        Creates an instance of AstraField with empty filters applied.
+        """
         self._field_name = field_name
-        self._field_filters: Dict[str, TField] = dict()
+        self._field_filters: Dict[str, TField] = {}
 
     @property
     def field_name(self):
+        """
+        Name of the wrapped field.
+        """
         return self._field_name
 
-    def with_filters(self, field_filters: Dict[str, TField]) -> 'AstraField[TField]':
+    def with_filters(self, field_filters: Dict[str, TField]) -> "AstraField[TField]":
+        """
+        Merge current filters with provided ones.
+        """
         self._field_filters.update(field_filters)
         return self
 
-    def isin(self, values: List[TField]) -> 'AstraField[TField]':
-        self._field_filters.update({
-            f"{self._field_name}__in": values
-        })
+    def isin(self, values: List[TField]) -> "AstraField[TField]":
+        """
+        Generates a filter condition checking that field value is one of the values provided.
+        """
+        self._field_filters.update({f"{self._field_name}__in": values})
 
         return self
 
-    def gt(self, value: TField) -> 'AstraField[TField]':
-        self._field_filters.update({
-            f"{self._field_name}__gt": value
-        })
+    def __gt__(self, value: TField) -> "AstraField[TField]":
+        """
+        Generates a filter condition checking that field is greater than value.
+        """
+        self._field_filters.update({f"{self._field_name}__gt": value})
 
         return self
 
-    def gte(self, value: TField) -> 'AstraField[TField]':
-        self._field_filters.update({
-            f"{self._field_name}__gte": value
-        })
+    def __ge__(self, value: TField) -> "AstraField[TField]":
+        """
+        Generates a filter condition checking that field is greater or equal to value.
+        """
+        self._field_filters.update({f"{self._field_name}__gte": value})
 
         return self
 
-    def lt(self, value: TField) -> 'AstraField[TField]':
-        self._field_filters.update({
-            f"{self._field_name}__lt": value
-        })
+    def __lt__(self, value: TField) -> "AstraField[TField]":
+        """
+        Generates a filter condition checking that field is less than a value.
+        """
+        self._field_filters.update({f"{self._field_name}__lt": value})
 
         return self
 
-    def lte(self, value: TField) -> 'AstraField[TField]':
-        self._field_filters.update({
-            f"{self._field_name}__lte": value
-        })
+    def __le__(self, value: TField) -> "AstraField[TField]":
+        """
+        Generates a filter condition checking that field is less than or equal to a value.
+        """
+        self._field_filters.update({f"{self._field_name}__lte": value})
 
         return self
 
-    def eq(self, value: TField) -> 'AstraField[TField]':
-        self._field_filters.update({
-            self._field_name: value
-        })
+    def __eq__(self, value: TField) -> "AstraField":  # type: ignore[override]
+        """
+        Generates a filter condition checking that field is equal to a value.
+        """
+        self._field_filters.update({self._field_name: value})
 
         return self
 
     @property
-    def field_filters(self) -> Dict[str, Any]:
+    def expression(self) -> Dict[str, Any]:
+        """
+        Return current filter set state.
+        """
         return self._field_filters
 
-    def __and__(self, other: 'AstraField[TField]') -> AstraFilterExpression:
-        assert isinstance(other, AstraField), f'Cannot concatenate this AstraField with object of type {type(other)}'
+    def __and__(self, other: "AstraField[TField]") -> AstraFilterExpression:
+        """
+        Combine two fields with AND.
+        """
+        assert isinstance(other, AstraField), f"Cannot concatenate this AstraField with object of type {type(other)}"
 
-        return AstraFilterExpression([self.field_filters | other.field_filters])
+        return AstraFilterExpression([self.expression | other.expression])
 
-    def __or__(self, other: 'AstraField[TField]') -> AstraFilterExpression:
-        assert isinstance(other, AstraField), f'Cannot concatenate this AstraField with object of type {type(other)}'
+    def __or__(self, other: "AstraField[TField]") -> AstraFilterExpression:
+        """
+        Combine two fields with OR.
+        """
+        assert isinstance(other, AstraField), f"Cannot concatenate this AstraField with object of type {type(other)}"
 
-        return AstraFilterExpression([self.field_filters, other.field_filters])
+        return AstraFilterExpression([self.expression, other.expression])

--- a/adapta/storage/distributed_object_store/datastax_astra/_models.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/_models.py
@@ -1,0 +1,99 @@
+"""
+ Auxiliary models for Astra client operations.
+"""
+from functools import reduce
+from typing import final, List, Dict, Generic, TypeVar, Union, Any
+
+TField = TypeVar('TField')
+
+
+class AstraFilterExpression:
+    def __init__(self, expr: List[Dict[str, Any]]):
+        self._expr = expr
+
+    @property
+    def expression(self) -> List[Dict[str, Any]]:
+        return self._expr
+
+    def __and__(self, other: 'AstraFilterExpression') -> 'AstraFilterExpression':
+        self._expr = reduce(lambda e1, e2: e1 | e2, self._expr + other.expression)
+        return self
+
+    def __or__(self, other: 'AstraFilterExpression') -> 'AstraFilterExpression':
+        self._expr = self._expr + other.expression
+        return self
+
+
+@final
+class AstraField(Generic[TField]):
+    """
+     Represents a field in the Astra table. Semantics mimic pyarrow.
+     Based on https://docs.datastax.com/en/developer/python-driver/3.24/cqlengine/queryset/
+    """
+    def __init__(self, field_name: str):
+        self._field_name = field_name
+        self._field_filters: Dict[str, TField] = dict()
+
+    @property
+    def field_name(self):
+        return self._field_name
+
+    def with_filters(self, field_filters: Dict[str, TField]) -> 'AstraField[TField]':
+        self._field_filters.update(field_filters)
+        return self
+
+    def isin(self, values: List[TField]) -> 'AstraField[TField]':
+        self._field_filters.update({
+            f"{self._field_name}__in": values
+        })
+
+        return self
+
+    def gt(self, value: TField) -> 'AstraField[TField]':
+        self._field_filters.update({
+            f"{self._field_name}__gt": value
+        })
+
+        return self
+
+    def gte(self, value: TField) -> 'AstraField[TField]':
+        self._field_filters.update({
+            f"{self._field_name}__gte": value
+        })
+
+        return self
+
+    def lt(self, value: TField) -> 'AstraField[TField]':
+        self._field_filters.update({
+            f"{self._field_name}__lt": value
+        })
+
+        return self
+
+    def lte(self, value: TField) -> 'AstraField[TField]':
+        self._field_filters.update({
+            f"{self._field_name}__lte": value
+        })
+
+        return self
+
+    def eq(self, value: TField) -> 'AstraField[TField]':
+        self._field_filters.update({
+            self._field_name: value
+        })
+
+        return self
+
+    @property
+    def field_filters(self) -> Dict[str, Any]:
+        return self._field_filters
+
+    def __and__(self, other: 'AstraField[TField]') -> AstraFilterExpression:
+        assert isinstance(other, AstraField), f'Cannot concatenate this AstraField with object of type {type(other)}'
+
+        return AstraFilterExpression([self.field_filters | other.field_filters])
+
+    def __or__(self, other: 'AstraField[TField]') -> AstraFilterExpression:
+        assert isinstance(other, AstraField), f'Cannot concatenate this AstraField with object of type {type(other)}'
+
+        return AstraFilterExpression([self.field_filters, other.field_filters])

--- a/adapta/storage/distributed_object_store/datastax_astra/_models.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/_models.py
@@ -1,7 +1,6 @@
 """
  Auxiliary models for Astra client operations.
 """
-from functools import reduce
 from typing import final, List, Dict, Generic, TypeVar, Any
 
 TField = TypeVar("TField")  # pylint: disable=invalid-name

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -181,7 +181,7 @@ class AstraClient:
     def filter_entities(
         self,
         model_class: Type[TModel],
-        key_column_filter_values: List[Dict[str, str]],
+        key_column_filter_values: List[Dict[str, Any]],
         table_name: Optional[str] = None,
         select_columns: Optional[List[str]] = None,
         primary_keys: Optional[List[str]] = None,

--- a/tests/test_filtering_api.py
+++ b/tests/test_filtering_api.py
@@ -21,12 +21,12 @@ TEST_ENTITY_SCHEMA: TestEntity = PythonSchemaEntity(TestEntity)
 @pytest.mark.parametrize(
     "filter_expression,expected_expression",
     [
-        (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test", {"col_a": "test"}),
-        (AstraField(TEST_ENTITY_SCHEMA.col_a) >= "test", {"col_a__gte": "test"}),
-        (AstraField(TEST_ENTITY_SCHEMA.col_a) > "test", {"col_a__gt": "test"}),
-        (AstraField(TEST_ENTITY_SCHEMA.col_a) < "test", {"col_a__lt": "test"}),
-        (AstraField(TEST_ENTITY_SCHEMA.col_a) <= "test", {"col_a__lte": "test"}),
-        (AstraField(TEST_ENTITY_SCHEMA.col_a).isin(["val1", "val2"]), {"col_a__in": ["val1", "val2"]}),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test", [{"col_a": "test"}]),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) >= "test", [{"col_a__gte": "test"}]),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) > "test", [{"col_a__gt": "test"}]),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) < "test", [{"col_a__lt": "test"}]),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) <= "test", [{"col_a__lte": "test"}]),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a).isin(["val1", "val2"]), [{"col_a__in": ["val1", "val2"]}]),
         (
             (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test") & (AstraField(TEST_ENTITY_SCHEMA.col_b) == "other"),
             [{"col_a": "test", "col_b": "other"}],
@@ -44,6 +44,11 @@ TEST_ENTITY_SCHEMA: TestEntity = PythonSchemaEntity(TestEntity)
             | (AstraField(TEST_ENTITY_SCHEMA.col_b) == "other")
             | (AstraField(TEST_ENTITY_SCHEMA.col_c) == 1),
             [{"col_a": "test"}, {"col_b": "other"}, {"col_c": 1}],
+        ),
+        (
+            ((AstraField(TEST_ENTITY_SCHEMA.col_a) == "test") | (AstraField(TEST_ENTITY_SCHEMA.col_b) == "other"))
+            & (AstraField(TEST_ENTITY_SCHEMA.col_c) == 1),
+            [{"col_a": "test", "col_c": 1}, {"col_b": "other", "col_c": 1}],
         ),
     ],
 )

--- a/tests/test_filtering_api.py
+++ b/tests/test_filtering_api.py
@@ -1,0 +1,53 @@
+import pytest
+
+from adapta.storage.distributed_object_store.datastax_astra import AstraField, AstraFilterExpression
+from adapta.schema_management.schema_entity import PythonSchemaEntity
+
+from dataclasses import dataclass, field
+from typing import List, Any, Dict, Union
+
+
+@dataclass
+class TestEntity:
+    col_a: str = field(metadata={"is_primary_key": True, "is_partition_key": True})
+    col_b: str = field(metadata={"is_primary_key": True, "is_partition_key": False})
+    col_c: int
+    col_d: List[int]
+
+
+TEST_ENTITY_SCHEMA: TestEntity = PythonSchemaEntity(TestEntity)
+
+
+@pytest.mark.parametrize(
+    "filter_expression,expected_expression",
+    [
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test", {"col_a": "test"}),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) >= "test", {"col_a__gte": "test"}),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) > "test", {"col_a__gt": "test"}),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) < "test", {"col_a__lt": "test"}),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a) <= "test", {"col_a__lte": "test"}),
+        (AstraField(TEST_ENTITY_SCHEMA.col_a).isin(["val1", "val2"]), {"col_a__in": ["val1", "val2"]}),
+        (
+            (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test") & (AstraField(TEST_ENTITY_SCHEMA.col_b) == "other"),
+            [{"col_a": "test", "col_b": "other"}],
+        ),
+        (
+            (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test") & (AstraField(TEST_ENTITY_SCHEMA.col_c).isin([1, 2, 3])),
+            [{"col_a": "test", "col_c__in": [1, 2, 3]}],
+        ),
+        (
+            (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test") | (AstraField(TEST_ENTITY_SCHEMA.col_b) == "other"),
+            [{"col_a": "test"}, {"col_b": "other"}],
+        ),
+        (
+            (AstraField(TEST_ENTITY_SCHEMA.col_a) == "test")
+            | (AstraField(TEST_ENTITY_SCHEMA.col_b) == "other")
+            | (AstraField(TEST_ENTITY_SCHEMA.col_c) == 1),
+            [{"col_a": "test"}, {"col_b": "other"}, {"col_c": 1}],
+        ),
+    ],
+)
+def test_astra_filters(
+    filter_expression: Union[AstraField, AstraFilterExpression], expected_expression: Dict[str, Any]
+):
+    assert filter_expression.expression == expected_expression


### PR DESCRIPTION
Closes #312 

## Scope

Implemented:
 - Added `AstraField` and `AstraFilterExpression` which follow pyarrow semantics when constructing filter expressions.
 - `AstraFilterExpression` and `AstraField` provide `expression` property which returns a ready-to-use `key_column_filter_expression` for `AstraClient`
 - Added support for combining expressions using magic methods (`e1 & e2` and `e1 | e2`)

Additional changes:
- Added units verifying expressions generated

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Self-review.
