### PR TITLE
324 feature decorator method runtime

### DIFF
--- a/adapta/utils/README.md
+++ b/adapta/utils/README.md
@@ -132,18 +132,21 @@ from adapta.logs import SemanticLogger
 from adapta.logs.models import LogLevel
 from adapta.utils import run_time_metrics
 
+
 @run_time_metrics(metric_name='example')
 def adder(number1, number2, logger=None, **_kwargs):
-    result = number1 + number2
-    logger.info(f'Sum of the numbers {result}')
-    return result
+  result = number1 + number2
+  logger.info('Sum of the numbers {result}', result=result)
+  return result
 
-@run_time_metrics(metric_name='update_message')
+
+@run_time_metrics(metric_name='update_message', log_level=LogLevel.INFO)
 def upgrade_message(message, logger=None, metrics_provider=None, **_kwargs):
-    message += ' : - )'
-    logger.info(message)
-    metrics_provider.gauge(metric_name="test_gauge", metric_value=1, tags={'env': 'test'})
-    return message
+  message += ' : - )'
+  logger.info(message)
+  metrics_provider.gauge(metric_name="test_gauge", metric_value=1, tags={'env': 'test'})
+  return message
+
 
 provider = DatadogMetricsProvider(metric_namespace='test')
 datadog_tags = {'source': 'wrapper'}

--- a/adapta/utils/README.md
+++ b/adapta/utils/README.md
@@ -111,19 +111,20 @@ with memory_limit(memory_limit_percentage=0.2):
 
 ### runtime_metrics:
 
-Decorator for logging method execution time and reporting function execution time to metric provider (DataDog).  
+Decorator for logging method execution time and reporting function execution time to metric provider (e.g. DataDog).  
 
 Notes:
-* Function call is logged with loglevel.INFO
-* Function runtime is logged with loglevel.DEBUG
+* When using the decorator the wrapped function must take logger and metrics_provider as keyword arguments.
+  * It is recommended to have decorated methods use `**kwargs` if logger and metric providers are not explicitly defined.
+* Logger sends logs with `loglevel.DEBUG`.
 
 Parameters:
-* method_type (optional): Type of method being wrapped. This will be used as a metric_name by the metric provider.
-* pass_logger (optional): If True, the logger will be passed to the wrapped function.
-* pass_metrics_provider (optional): If True, the metrics provider will be passed to the wrapped function.
-* extra_metric_entities (optional): Dictionary containing extra tags used by the metric provider.
+* `metric_name`: Type of method being wrapped. This will be used as a metric_name by the metric provider.
+* `tag_function_name` (optional): If True function name will be added as additional metric_tag. Defaults to False.
+* `metric_tags` (optional): Dictionary containing extra tags used by the metric provider.
 
 Example Usage:
+
 ```python
 import time
 from adapta.metrics.providers.datadog_provider import DatadogMetricsProvider
@@ -132,19 +133,18 @@ from adapta.logs.models import LogLevel
 from adapta.utils import run_time_metrics
 
 
-@run_time_metrics(method_type='example', pass_logger=True, pass_metrics_provider=True)
-def example_function(logger=None, metrics_provider=None):
+@run_time_metrics(metric_name='example')
+def example_function(logger=None, metrics_provider=None, **kwargs):
     time.sleep(1)
-    if logger:
-        logger.info('Logging from the example function')
-    if metrics_provider:
-        metrics_provider.gauge(metric_name="test_gauge", metric_value=1, tags={'env': 'test'})
+    logger.info('Logging from the example function')
+    metrics_provider.gauge(metric_name="test_gauge", metric_value=1, tags={'env': 'test'})
     return True
 
 
 provider = DatadogMetricsProvider(metric_namespace='test')
 datadog_tags = {'source': 'wrapper'}
-semantic_logger = SemanticLogger().add_log_source(log_source_name='test_logger_1', min_log_level=LogLevel.DEBUG, is_default=True)
+semantic_logger = SemanticLogger().add_log_source(log_source_name='test_logger_1', min_log_level=LogLevel.DEBUG,
+                                                  is_default=True)
 
-example_function(logger=semantic_logger, metrics_provider=provider, extra_metric_entities=datadog_tags)
+example_function(logger=semantic_logger, metrics_provider=provider, metric_tags=datadog_tags)
 ```

--- a/adapta/utils/__init__.py
+++ b/adapta/utils/__init__.py
@@ -18,3 +18,4 @@
 #
 
 from adapta.utils._common import *
+from adapta.utils.decorators import run_time_metrics

--- a/adapta/utils/decorators/__init__.py
+++ b/adapta/utils/decorators/__init__.py
@@ -1,0 +1,2 @@
+""" Method utility decorators. """
+from ._logging import run_time_metrics

--- a/adapta/utils/decorators/__init__.py
+++ b/adapta/utils/decorators/__init__.py
@@ -1,2 +1,2 @@
 """ Method utility decorators. """
-from ._logging import run_time_metrics
+from adapta.utils.decorators._logging import run_time_metrics

--- a/adapta/utils/decorators/_logging.py
+++ b/adapta/utils/decorators/_logging.py
@@ -1,0 +1,51 @@
+""" Module for common decorator methods. """
+from functools import wraps
+
+from adapta.logs import SemanticLogger
+from adapta.metrics import MetricsProvider
+from adapta.utils import operation_time
+
+
+def run_time_metrics(method_type: str, pass_logger: bool = False, pass_metrics_provider: bool = False):
+    """
+    Decorator which can be used to log automatically runtime of a method.
+
+    :param method_type: Description of method type that can be used to capture logging in metric sink.
+    :param pass_logger: Boolean flag that denotes if logger should be passed onwards to decorated method.
+    :param pass_metrics_provider: Boolean flag that denotes if metric_provider should be pasesd to decorated method.
+    """
+
+    def outer_runtime_decorator(func):
+        @wraps(func)
+        def inner_runtime_decorator(*args, **kwargs):
+            logger: SemanticLogger = kwargs.get("logger", None) if pass_logger else kwargs.pop("logger", None)
+            metrics_provider: MetricsProvider = (
+                kwargs.get("metrics_provider", None) if pass_metrics_provider else kwargs.pop("metrics_provider", None)
+            )
+            extra_entities = kwargs.pop("extra_metric_entities", {})
+
+            if logger is not None:
+                logger.info(
+                    "running {run_type} on method {method_name}", run_type=method_type, method_name=func.__name__
+                )
+
+            with operation_time() as ot:
+                result = func(*args, **kwargs)
+
+            if metrics_provider is not None:
+                metrics_provider.gauge(
+                    metric_name=f"{method_type}",
+                    metric_value=round(ot.elapsed / 1e9, 2),
+                    tags={"entity_name": str(func.__name__)} | extra_entities,
+                )
+            if logger is not None:
+                logger.debug(
+                    "{method_name} finished in {elapsed:.2f}s seconds",
+                    method_name=func.__name__,
+                    elapsed=(ot.elapsed / 1e9),
+                )
+            return result
+
+        return inner_runtime_decorator
+
+    return outer_runtime_decorator

--- a/adapta/utils/decorators/_logging.py
+++ b/adapta/utils/decorators/_logging.py
@@ -6,44 +6,35 @@ from adapta.metrics import MetricsProvider
 from adapta.utils._common import operation_time
 
 
-def run_time_metrics(method_type: str, pass_logger: bool = False, pass_metrics_provider: bool = False):
+def run_time_metrics(metric_name: str, tag_function_name: bool = False):
     """
-    Decorator which can be used to log automatically runtime of a method.
+    Decorator that records runtime of decorated method to logging source and metrics_provider.
 
-    :param method_type: Description of method type that can be used to capture logging in metric sink.
-    :param pass_logger: Boolean flag that denotes if logger should be passed onwards to decorated method.
-    :param pass_metrics_provider: Boolean flag that denotes if metric_provider should be pasesd to decorated method.
+    :param metric_name: Description of method type that can be used to capture logging in metric sink.
+    :param tag_function_name: Boolean flag to indicate if function name should be added as tag to metric. Default False.
     """
 
     def outer_runtime_decorator(func):
         @wraps(func)
         def inner_runtime_decorator(*args, **kwargs):
-            logger: SemanticLogger = kwargs.get("logger", None) if pass_logger else kwargs.pop("logger", None)
-            metrics_provider: MetricsProvider = (
-                kwargs.get("metrics_provider", None) if pass_metrics_provider else kwargs.pop("metrics_provider", None)
-            )
-            extra_entities = kwargs.pop("extra_metric_entities", {})
+            logger: SemanticLogger = kwargs.get("logger")
+            metrics_provider: MetricsProvider = kwargs.get("metrics_provider")
+            metric_tags = kwargs.pop("metric_tags", {})
+            metric_tags |= {"function_name": str(func.__name__)} if tag_function_name else {}
 
-            if logger is not None:
-                logger.info(
-                    "running {run_type} on method {method_name}", run_type=method_type, method_name=func.__name__
-                )
-
+            logger.debug("running {run_type} on method {method_name}", run_type=metric_name, method_name=func.__name__)
             with operation_time() as ot:
                 result = func(*args, **kwargs)
-
-            if metrics_provider is not None:
-                metrics_provider.gauge(
-                    metric_name=f"{method_type}",
-                    metric_value=round(ot.elapsed / 1e9, 2),
-                    tags={"entity_name": str(func.__name__)} | extra_entities,
-                )
-            if logger is not None:
-                logger.debug(
-                    "{method_name} finished in {elapsed:.2f}s seconds",
-                    method_name=func.__name__,
-                    elapsed=(ot.elapsed / 1e9),
-                )
+            metrics_provider.gauge(
+                metric_name=metric_name,
+                metric_value=round(ot.elapsed / 1e9, 2),
+                tags=metric_tags,
+            )
+            logger.debug(
+                "{method_name} finished in {elapsed:.2f}s seconds",
+                method_name=func.__name__,
+                elapsed=(ot.elapsed / 1e9),
+            )
             return result
 
         return inner_runtime_decorator

--- a/adapta/utils/decorators/_logging.py
+++ b/adapta/utils/decorators/_logging.py
@@ -2,27 +2,37 @@
 from functools import wraps
 
 from adapta.logs import SemanticLogger
+from adapta.logs.models import LogLevel
 from adapta.metrics import MetricsProvider
 from adapta.utils._common import operation_time
 
 
-def run_time_metrics(metric_name: str, tag_function_name: bool = False):
+def run_time_metrics(metric_name: str, tag_function_name: bool = False, reporting_level: LogLevel = LogLevel.DEBUG):
     """
     Decorator that records runtime of decorated method to logging source and metrics_provider.
 
     :param metric_name: Description of method type that can be used to capture logging in metric sink.
     :param tag_function_name: Boolean flag to indicate if function name should be added as tag to metric. Default False.
+    :param reporting_level: Defines on which level the logger should send reports. Default debug.
     """
 
     def outer_runtime_decorator(func):
         @wraps(func)
         def inner_runtime_decorator(*args, **kwargs):
-            logger: SemanticLogger = kwargs.get("logger")
-            metrics_provider: MetricsProvider = kwargs.get("metrics_provider")
+            logger: SemanticLogger = kwargs.get("logger", None)
+            metrics_provider: MetricsProvider = kwargs.get("metrics_provider", None)
+            if logger is None or metrics_provider is None:
+                raise AttributeError(
+                    f"Decorated wrapped function: {func.__name__} missing required objects logger, metrics_provider"
+                )
+            log_method = getattr(logger, reporting_level.value.lower())
+            if log_method is None:
+                raise AttributeError(f"Logger {logger.__class__} does not send logs on level: {reporting_level}")
+
             metric_tags = kwargs.pop("metric_tags", {})
             metric_tags |= {"function_name": str(func.__name__)} if tag_function_name else {}
 
-            logger.debug("running {run_type} on method {method_name}", run_type=metric_name, method_name=func.__name__)
+            log_method("running {run_type} on method {method_name}", run_type=metric_name, method_name=func.__name__)
             with operation_time() as ot:
                 result = func(*args, **kwargs)
             metrics_provider.gauge(
@@ -30,7 +40,7 @@ def run_time_metrics(metric_name: str, tag_function_name: bool = False):
                 metric_value=round(ot.elapsed / 1e9, 2),
                 tags=metric_tags,
             )
-            logger.debug(
+            log_method(
                 "{method_name} finished in {elapsed:.2f}s seconds",
                 method_name=func.__name__,
                 elapsed=(ot.elapsed / 1e9),

--- a/adapta/utils/decorators/_logging.py
+++ b/adapta/utils/decorators/_logging.py
@@ -7,13 +7,13 @@ from adapta.metrics import MetricsProvider
 from adapta.utils._common import operation_time
 
 
-def run_time_metrics(metric_name: str, tag_function_name: bool = False, reporting_level: LogLevel = LogLevel.DEBUG):
+def run_time_metrics(metric_name: str, tag_function_name: bool = False, log_level: LogLevel = LogLevel.DEBUG):
     """
     Decorator that records runtime of decorated method to logging source and metrics_provider.
 
     :param metric_name: Description of method type that can be used to capture logging in metric sink.
     :param tag_function_name: Boolean flag to indicate if function name should be added as tag to metric. Default False.
-    :param reporting_level: Defines on which level the logger should send reports. Default debug.
+    :param log_level: Defines on which level the logger should send reports. Default debug.
     """
 
     def outer_runtime_decorator(func):
@@ -25,9 +25,9 @@ def run_time_metrics(metric_name: str, tag_function_name: bool = False, reportin
                 raise AttributeError(
                     f"Decorated wrapped function: {func.__name__} missing required objects logger, metrics_provider"
                 )
-            log_method = getattr(logger, reporting_level.value.lower())
+            log_method = getattr(logger, log_level.value.lower())
             if log_method is None:
-                raise AttributeError(f"Logger {logger.__class__} does not send logs on level: {reporting_level}")
+                raise AttributeError(f"Logger {logger.__class__} does not send logs on level: {log_level}")
 
             metric_tags = kwargs.pop("metric_tags", {}) | (
                 {"function_name": str(func.__name__)} if tag_function_name else {}

--- a/adapta/utils/decorators/_logging.py
+++ b/adapta/utils/decorators/_logging.py
@@ -29,8 +29,9 @@ def run_time_metrics(metric_name: str, tag_function_name: bool = False, reportin
             if log_method is None:
                 raise AttributeError(f"Logger {logger.__class__} does not send logs on level: {reporting_level}")
 
-            metric_tags = kwargs.pop("metric_tags", {})
-            metric_tags |= {"function_name": str(func.__name__)} if tag_function_name else {}
+            metric_tags = kwargs.pop("metric_tags", {}) | (
+                {"function_name": str(func.__name__)} if tag_function_name else {}
+            )
 
             log_method("running {run_type} on method {method_name}", run_type=metric_name, method_name=func.__name__)
             with operation_time() as ot:

--- a/adapta/utils/decorators/_logging.py
+++ b/adapta/utils/decorators/_logging.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 from adapta.logs import SemanticLogger
 from adapta.metrics import MetricsProvider
-from adapta.utils import operation_time
+from adapta.utils._common import operation_time
 
 
 def run_time_metrics(method_type: str, pass_logger: bool = False, pass_metrics_provider: bool = False):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,7 +261,8 @@ def test_data_adapter(drop_missing: bool):
 
 @pytest.mark.parametrize("reporting_level", [LogLevel.DEBUG, LogLevel.INFO])
 @pytest.mark.parametrize("loglevel", [LogLevel.DEBUG, LogLevel.INFO])
-def test_runtime_decorator(caplog, reporting_level, loglevel):
+@pytest.mark.parametrize("tag_func_name", [True, False])
+def test_runtime_decorator(caplog, reporting_level, loglevel, tag_func_name):
     """
     Test that run_time_metrics_decorator reports correct information for every run of the algorithm.
 
@@ -280,8 +281,11 @@ def test_runtime_decorator(caplog, reporting_level, loglevel):
     )
 
     class DummyMetricProvider:
-        def gauge(self, **_kwargs):
-            return True
+        def gauge(self, metric_name, metric_value, tags):
+            """Dummy provider to assert passed values"""
+            assert metric_name == run_type
+            assert type(metric_value) == float
+            assert ~tag_func_name or tags["function_name"] == "test_function"
 
     metrics_provider = DummyMetricProvider()
     run_type = "test_execution"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -302,8 +302,9 @@ def test_runtime_decorator(caplog, reporting_level, loglevel):
 
 
 def test_missing_decorator_error():
-    """ Assert that readable error is raised when decorator (logger, metric provider) attributes are missing """
-    @run_time_metrics(metric_name='test_execution')
+    """Assert that readable error is raised when decorator (logger, metric provider) attributes are missing"""
+
+    @run_time_metrics(metric_name="test_execution")
     def test_function(logger, **_kwargs):
         return
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -285,13 +285,13 @@ def test_runtime_decorator(caplog, reporting_level, loglevel, tag_func_name):
             """Dummy provider to assert passed values"""
             assert metric_name == run_type
             assert type(metric_value) == float
-            assert ~tag_func_name or tags["function_name"] == "test_function"
+            assert not tag_func_name or tags["function_name"] == "test_function"
 
     metrics_provider = DummyMetricProvider()
     run_type = "test_execution"
     print_from_func = "from_function_call"
 
-    @run_time_metrics(metric_name=run_type, tag_function_name=True, reporting_level=reporting_level)
+    @run_time_metrics(metric_name=run_type, tag_function_name=True, log_level=reporting_level)
     def test_function(logger, **_kwargs):
         logger.info(print_from_func)
         return True
@@ -309,7 +309,7 @@ def test_missing_decorator_error():
     """Assert that readable error is raised when decorator (logger, metric provider) attributes are missing"""
 
     @run_time_metrics(metric_name="test_execution")
-    def test_function(logger, **_kwargs):
+    def test_function(**_kwargs):
         return
 
     with pytest.raises(AttributeError):


### PR DESCRIPTION
Implements common runtime decorator that supports SemanticLogger and DataDogMetricProvider

## Scope

Implemented:
- Wrapper that automatically sends function runtimes

Additional changes:
- Implement test for the decorator (only for logging, not for metrics)

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
