### PR TITLE
Fix astra key_column_filter_values type

### DIFF
--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -247,7 +247,11 @@ class AstraClient:
             select_columns=select_columns,
         )
 
-        compiled_filter_values = compile_expression(key_column_filter_values, AstraFilterExpression)
+        compiled_filter_values = (
+            compile_expression(key_column_filter_values, AstraFilterExpression)
+            if isinstance(key_column_filter_values, Expression)
+            else key_column_filter_values
+        )
 
         if num_threads:
             with ThreadPoolExecutor(max_workers=num_threads) as tpe:

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -28,7 +28,7 @@ import typing
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import fields, is_dataclass
-from typing import Optional, Dict, TypeVar, Callable, Type, List, Any, get_origin
+from typing import Optional, Dict, TypeVar, Callable, Type, List, Any, get_origin, Union
 
 from _socket import IPPROTO_TCP, TCP_NODELAY, TCP_USER_TIMEOUT
 
@@ -52,6 +52,7 @@ from cassandra.policies import ExponentialReconnectionPolicy
 from cassandra.query import dict_factory  # pylint: disable=E0611
 
 from adapta import __version__
+from adapta.storage.models.filter_expression import Expression
 
 TModel = TypeVar("TModel")  # pylint: disable=C0103
 
@@ -183,7 +184,7 @@ class AstraClient:
     def filter_entities(
         self,
         model_class: Type[TModel],
-        key_column_filter_values: List[Dict[str, Any]],
+        key_column_filter_values: Union[Expression, List[Dict[str, Any]]],
         table_name: Optional[str] = None,
         select_columns: Optional[List[str]] = None,
         primary_keys: Optional[List[str]] = None,

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -273,9 +273,7 @@ class AstraClient:
 
         if select_columns:
             filter_columns = {
-                normalize_column_name(key)
-                for key_column_filter in compiled_filter_values
-                for key in key_column_filter
+                normalize_column_name(key) for key_column_filter in compiled_filter_values for key in key_column_filter
             }
             result = result.drop(columns=list(set(filter_columns) - set(select_columns)))
 
@@ -313,9 +311,15 @@ class AstraClient:
         def map_to_column(  # pylint: disable=R0911
             python_type: Type,
         ) -> typing.Union[
-            typing.Tuple[Type[columns.List],],
-            typing.Tuple[Type[columns.Map],],
-            typing.Tuple[Type[Column],],
+            typing.Tuple[
+                Type[columns.List],
+            ],
+            typing.Tuple[
+                Type[columns.Map],
+            ],
+            typing.Tuple[
+                Type[Column],
+            ],
             typing.Tuple[Type[Column], Type[Column]],
             typing.Tuple[Type[Column], Type[Column], Type[Column]],
         ]:

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -275,7 +275,7 @@ class AstraClient:
             filter_columns = {
                 normalize_column_name(key)
                 for key_column_filter in compiled_filter_values
-                for key in key_column_filter.keys()
+                for key in key_column_filter
             }
             result = result.drop(columns=list(set(filter_columns) - set(select_columns)))
 

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -311,15 +311,9 @@ class AstraClient:
         def map_to_column(  # pylint: disable=R0911
             python_type: Type,
         ) -> typing.Union[
-            typing.Tuple[
-                Type[columns.List],
-            ],
-            typing.Tuple[
-                Type[columns.Map],
-            ],
-            typing.Tuple[
-                Type[Column],
-            ],
+            typing.Tuple[Type[columns.List],],
+            typing.Tuple[Type[columns.Map],],
+            typing.Tuple[Type[Column],],
             typing.Tuple[Type[Column], Type[Column]],
             typing.Tuple[Type[Column], Type[Column], Type[Column]],
         ]:


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
 - Fix astra key_column_filter_values type 


## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
