### PR TITLE
Fix to astra fetching when returning empty dataframe

### DIFF
--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -265,7 +265,7 @@ class AstraClient:
             self._session is not None
         ), "Please instantiate an AstraClient using with AstraClient(...) before calling this method"
 
-        select_columns = list(map(normalize_column_name, select_columns)) if select_columns else None
+        select_columns = list(map(normalize_column_name, select_columns)) if select_columns else [f.name for f in fields(model_class)]
 
         model_class: Type[Model] = self._model_dataclass(
             value=model_class,

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -265,7 +265,11 @@ class AstraClient:
             self._session is not None
         ), "Please instantiate an AstraClient using with AstraClient(...) before calling this method"
 
-        select_columns = list(map(normalize_column_name, select_columns)) if select_columns else [f.name for f in fields(model_class)]
+        select_columns = (
+            list(map(normalize_column_name, select_columns))
+            if select_columns
+            else [f.name for f in fields(model_class)]
+        )
 
         model_class: Type[Model] = self._model_dataclass(
             value=model_class,


### PR DESCRIPTION
If no columns were specificied, a dataframe with no columns was returned. It now references the model_class and returns an empty dataframe from this. 