### PR TITLE
Fix bug in filter_entities

### DIFF
--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -309,12 +309,6 @@ class AstraClient:
                 ]
             )
 
-        if select_columns:
-            filter_columns = {
-                normalize_column_name(key) for key_column_filter in compiled_filter_values for key in key_column_filter
-            }
-            result = result.drop(columns=list(set(filter_columns) - set(select_columns)))
-
         if deduplicate:
             return result.drop_duplicates()
 


### PR DESCRIPTION
For a filter of the type:

```
        filters = reduce(
            lambda x, y: x | y,
            [
                (
                    (FilterField(ASSORTMENT_RO.sku_key) == sku_key)
                    & (FilterField(ASSORTMENT_RO.country_code) == country_code)
                )
                for sku_key in sku_key_set
            ],
        )
```
used to filter the return optimizer assortment table, will meet a bug as the select_columns not contains country_code. 
This is fixed by removing the if-statement that drops all columns not selected.

The bug is due to the country_code column already beeing dropped (or more precisely not chosen), when the result is constructed.