### PR TITLE
Print for filter expressions

### DIFF
--- a/adapta/_version.py
+++ b/adapta/_version.py
@@ -1,7 +1,6 @@
 """
  Package version.
 """
-
 #  Copyright (c) 2023. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/adapta/_version.py
+++ b/adapta/_version.py
@@ -15,5 +15,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
 __version__ = "0.0.0"  # replaced by git tag on publish

--- a/adapta/_version.py
+++ b/adapta/_version.py
@@ -1,6 +1,7 @@
 """
  Package version.
 """
+
 #  Copyright (c) 2023. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,4 +16,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
 __version__ = "0.0.0"  # replaced by git tag on publish

--- a/adapta/storage/models/filter_expression.py
+++ b/adapta/storage/models/filter_expression.py
@@ -50,7 +50,9 @@ class FilterExpressionOperation(Enum):
             FilterExpressionOperation.EQ: "==",
             FilterExpressionOperation.IN: "IN",
         }
-        return operation_strings.get(self, "")
+        if self not in operation_strings:
+            raise ValueError(f"Operation {self} not recognized")
+        return operation_strings[self]
 
 
 @final

--- a/adapta/storage/models/filter_expression.py
+++ b/adapta/storage/models/filter_expression.py
@@ -122,13 +122,13 @@ class Expression:
     """
 
     def __init__(
-            self,
-            left_operand: Union["Expression", FilterField],
-            right_operand: Union["Expression", Any, List],
-            operation: FilterExpressionOperation,
+        self,
+        left_operand: Union["Expression", FilterField],
+        right_operand: Union["Expression", Any, List],
+        operation: FilterExpressionOperation,
     ):
         assert (isinstance(left_operand, Expression) and isinstance(right_operand, Expression)) or (
-                isinstance(left_operand, FilterField) and not isinstance(right_operand, FilterExpression)
+            isinstance(left_operand, FilterField) and not isinstance(right_operand, FilterExpression)
         ), (
             "Both left and right operands must either be of type "
             "'Expression' or the left operand should be of type "
@@ -166,7 +166,7 @@ class FilterExpression(Generic[TCompileResult], ABC):
 
     @abstractmethod
     def _compile_base_case(
-            self, field_name: str, field_values: Any, operation: FilterExpressionOperation
+        self, field_name: str, field_values: Any, operation: FilterExpressionOperation
     ) -> TCompileResult:
         """
         Compiles the base case of a filter expression.
@@ -174,8 +174,7 @@ class FilterExpression(Generic[TCompileResult], ABC):
 
     @abstractmethod
     def _combine_results(
-            self, compiled_result_a: TCompileResult, compiled_result_b: TCompileResult,
-            operation: FilterExpressionOperation
+        self, compiled_result_a: TCompileResult, compiled_result_b: TCompileResult, operation: FilterExpressionOperation
     ) -> TCompileResult:
         """
         Combines two compiled results of filter expressions.
@@ -201,13 +200,12 @@ class AstraFilterExpression(FilterExpression[List[Dict[str, Any]]]):
     """
 
     def _compile_base_case(
-            self, field_name: str, field_values: Any, operation: FilterExpressionOperation
+        self, field_name: str, field_values: Any, operation: FilterExpressionOperation
     ) -> TCompileResult:
         return [{f"{field_name}{operation.value['astra']}": field_values}]
 
     def _combine_results(
-            self, compiled_result_a: TCompileResult, compiled_result_b: TCompileResult,
-            operation: FilterExpressionOperation
+        self, compiled_result_a: TCompileResult, compiled_result_b: TCompileResult, operation: FilterExpressionOperation
     ) -> TCompileResult:
         return operation.value["astra"](compiled_result_a, compiled_result_b)
 
@@ -219,15 +217,15 @@ class ArrowFilterExpression(FilterExpression[pyarrow.compute.Expression]):
     """
 
     def _compile_base_case(
-            self, field_name: str, field_values: Any, filter_operation: FilterExpressionOperation
+        self, field_name: str, field_values: Any, filter_operation: FilterExpressionOperation
     ) -> TCompileResult:
         return filter_operation.value["arrow"](pyarrow_field(field_name), field_values)
 
     def _combine_results(
-            self,
-            compiled_result_a: TCompileResult,
-            compiled_result_b: TCompileResult,
-            filter_operation: FilterExpressionOperation,
+        self,
+        compiled_result_a: TCompileResult,
+        compiled_result_b: TCompileResult,
+        filter_operation: FilterExpressionOperation,
     ) -> TCompileResult:
         return filter_operation.value["arrow"](compiled_result_a, compiled_result_b)
 

--- a/tests/test_filtering_api.py
+++ b/tests/test_filtering_api.py
@@ -111,6 +111,9 @@ def test_generic_filtering(
     [
         (FilterField(TEST_ENTITY_SCHEMA.col_a) == "test", "col_a == test"),
         (FilterField(TEST_ENTITY_SCHEMA.col_a) > "test", "col_a > test"),
+        (FilterField(TEST_ENTITY_SCHEMA.col_a) >= "test", "col_a >= test"),
+        (FilterField(TEST_ENTITY_SCHEMA.col_a) < "test", "col_a < test"),
+        (FilterField(TEST_ENTITY_SCHEMA.col_a) <= "test", "col_a <= test"),
         (
             (
                 (FilterField(TEST_ENTITY_SCHEMA.col_a) == "test") & (FilterField(TEST_ENTITY_SCHEMA.col_c) == 1)

--- a/tests/test_filtering_api.py
+++ b/tests/test_filtering_api.py
@@ -104,3 +104,22 @@ def test_generic_filtering(
 ):
     assert compile_expression(filter_expr, ArrowFilterExpression).equals(pyarrow_expected_expr)
     assert compile_expression(filter_expr, AstraFilterExpression) == astra_expected_expr
+
+
+@pytest.mark.parametrize(
+    "filter_expr, expected_output",
+    [
+        (FilterField(TEST_ENTITY_SCHEMA.col_a) == "test", "col_a == test"),
+        (FilterField(TEST_ENTITY_SCHEMA.col_a) > "test", "col_a > test"),
+        (
+            (
+                (FilterField(TEST_ENTITY_SCHEMA.col_a) == "test") & (FilterField(TEST_ENTITY_SCHEMA.col_c) == 1)
+                | (FilterField(TEST_ENTITY_SCHEMA.col_b) == "other")
+                & ((FilterField(TEST_ENTITY_SCHEMA.col_c) == 2) | (FilterField(TEST_ENTITY_SCHEMA.col_d).isin([1, 2])))
+            ),
+            "((col_a == test) AND (col_c == 1)) OR ((col_b == other) AND ((col_c == 2) OR (col_d IN [1, 2])))",
+        ),
+    ],
+)
+def test_print_filter_expression(filter_expr: FilterExpression, expected_output: str):
+    assert str(filter_expr) == expected_output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ def mock_func(a: float, b: str, c: bool) -> Dict:
         (
             # Run 3 functions in 3 threads
             # Each function sleeps for `a` seconds before returning
-            # Since we do lazy result fetch, we should expect to wait LESS than max(a0,.. aN), because all tasks effectively start at the same time
+            # Since we do lazy result fetch, we should expect to wait around max(a0,.. aN), because all tasks effectively start at the same time
             # however since time.sleep effectively blocks the main thread if using ThreadPoolExecutor, subsequent submissions will delay each other
             # thus we should expect at most 0.5s + small time to get results of each future.
             [
@@ -92,7 +92,7 @@ def mock_func(a: float, b: str, c: bool) -> Dict:
                 "case2": {"a": 0.3, "b": "test1", "c": True},
                 "case3": {"a": 0.5, "b": "test2", "c": False},
             },
-            0.55,
+            0.65,
         ),
         # Runs 1 thread for each function
         # Expected to see 1s + 2s + 3s + result process time ~ slightly above 6s


### PR DESCRIPTION
Closes #347 

## Scope

Implemented:
 - Adds print capabilities for Filter Expressions, which prints the actual value of a filter expression by calling the print() function on the expression object.
 - Added __str__ for Expression which transforms an expression into a string representation
 - Added to_string for FilterExpressionOperation which  maps each FilterExpressionOperation to its corresponding string representation using a dictionary
 
## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
