### PR TITLE
Chunk list for isin() if list length > 25

### DIFF
--- a/adapta/storage/models/filter_expression.py
+++ b/adapta/storage/models/filter_expression.py
@@ -218,11 +218,10 @@ class AstraFilterExpression(FilterExpression[List[Dict[str, Any]]]):
         self, field_name: str, field_values: List[Any], operation: FilterExpressionOperation
     ) -> TCompileResult:
         # Compile each chunk into an IN operation expression
-        compiled_chunks = [
+        return [
             {f"{field_name}{operation.value['astra']}": chunk}
             for chunk in chunk_list(field_values, math.ceil(len(field_values) / 25))
         ]
-        return compiled_chunks
 
 
 @final

--- a/tests/test_filtering_api.py
+++ b/tests/test_filtering_api.py
@@ -126,3 +126,181 @@ def test_generic_filtering(
 )
 def test_print_filter_expression(filter_expr: FilterExpression, expected_output: str):
     assert str(filter_expr) == expected_output
+
+
+@pytest.mark.parametrize(
+    "filter_expr, pyarrow_expected_expr, astra_expected_expr",
+    [
+        (
+            (
+                FilterField(TEST_ENTITY_SCHEMA.col_d).isin(
+                    [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "5",
+                        "6",
+                        "7",
+                        "8",
+                        "9",
+                        "10",
+                        "11",
+                        "12",
+                        "13",
+                        "14",
+                        "15",
+                        "16",
+                        "17",
+                        "18",
+                        "19",
+                        "20",
+                        "21",
+                        "22",
+                        "23",
+                        "24",
+                        "25",
+                        "26",
+                        "27",
+                    ]
+                )
+            ),
+            (
+                (
+                    pyarrow_field("col_d").isin(
+                        ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"]
+                    )
+                    | pyarrow_field("col_d").isin(
+                        [
+                            "15",
+                            "16",
+                            "17",
+                            "18",
+                            "19",
+                            "20",
+                            "21",
+                            "22",
+                            "23",
+                            "24",
+                            "25",
+                            "26",
+                            "27",
+                        ]
+                    )
+                )
+            ),
+            (
+                [
+                    {"col_d__in": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"]},
+                    {"col_d__in": ["15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27"]},
+                ]
+            ),
+        ),
+        (
+            (
+                FilterField(TEST_ENTITY_SCHEMA.col_d).isin(
+                    [
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "5",
+                        "6",
+                        "7",
+                        "8",
+                        "9",
+                        "10",
+                        "11",
+                        "12",
+                        "13",
+                        "14",
+                        "15",
+                        "16",
+                        "17",
+                        "18",
+                        "19",
+                        "20",
+                        "21",
+                        "22",
+                        "23",
+                        "24",
+                        "25",
+                    ]
+                )
+            ),
+            (
+                (
+                    pyarrow_field("col_d").isin(
+                        [
+                            "1",
+                            "2",
+                            "3",
+                            "4",
+                            "5",
+                            "6",
+                            "7",
+                            "8",
+                            "9",
+                            "10",
+                            "11",
+                            "12",
+                            "13",
+                            "14",
+                            "15",
+                            "16",
+                            "17",
+                            "18",
+                            "19",
+                            "20",
+                            "21",
+                            "22",
+                            "23",
+                            "24",
+                            "25",
+                        ]
+                    )
+                )
+            ),
+            (
+                [
+                    {
+                        "col_d__in": [
+                            "1",
+                            "2",
+                            "3",
+                            "4",
+                            "5",
+                            "6",
+                            "7",
+                            "8",
+                            "9",
+                            "10",
+                            "11",
+                            "12",
+                            "13",
+                            "14",
+                            "15",
+                            "16",
+                            "17",
+                            "18",
+                            "19",
+                            "20",
+                            "21",
+                            "22",
+                            "23",
+                            "24",
+                            "25",
+                        ]
+                    },
+                ]
+            ),
+        ),
+    ],
+)
+def test_long_is_in_list(
+    filter_expr: Union[FilterField, FilterExpression],
+    pyarrow_expected_expr: pc.Expression,
+    astra_expected_expr: Dict[str, Any],
+):
+    assert compile_expression(filter_expr, ArrowFilterExpression).equals(pyarrow_expected_expr)
+    assert compile_expression(filter_expr, AstraFilterExpression) == astra_expected_expr

--- a/tests/test_filtering_api.py
+++ b/tests/test_filtering_api.py
@@ -133,12 +133,7 @@ def test_print_filter_expression(filter_expr: FilterExpression, expected_output:
     [
         (
             (FilterField(TEST_ENTITY_SCHEMA.col_d).isin([str(i) for i in range(1, 28)])),
-            (
-                (
-                    pyarrow_field("col_d").isin([str(i) for i in range(1, 15)])
-                    | pyarrow_field("col_d").isin([str(i) for i in range(15, 28)])
-                )
-            ),
+            ((pyarrow_field("col_d").isin([str(i) for i in range(1, 28)]))),
             (
                 [
                     {"col_d__in": [str(i) for i in range(1, 15)]},
@@ -148,7 +143,7 @@ def test_print_filter_expression(filter_expr: FilterExpression, expected_output:
         ),
         (
             (FilterField(TEST_ENTITY_SCHEMA.col_d).isin([str(i) for i in range(1, 26)])),
-            ((pyarrow_field("col_d").isin([str(i) for i in range(1, 26)]))),
+            (pyarrow_field("col_d").isin([str(i) for i in range(1, 26)])),
             (
                 [
                     {"col_d__in": [str(i) for i in range(1, 26)]},
@@ -157,14 +152,7 @@ def test_print_filter_expression(filter_expr: FilterExpression, expected_output:
         ),
         (
             (FilterField(TEST_ENTITY_SCHEMA.col_d).isin([str(i) for i in range(1, 101)])),
-            (
-                (
-                    pyarrow_field("col_d").isin([str(i) for i in range(1, 26)])
-                    | pyarrow_field("col_d").isin([str(i) for i in range(26, 51)])
-                    | pyarrow_field("col_d").isin([str(i) for i in range(51, 76)])
-                    | pyarrow_field("col_d").isin([str(i) for i in range(76, 101)])
-                )
-            ),
+            ((pyarrow_field("col_d").isin([str(i) for i in range(1, 101)]))),
             (
                 [
                     {"col_d__in": [str(i) for i in range(1, 26)]},

--- a/tests/test_filtering_api.py
+++ b/tests/test_filtering_api.py
@@ -132,166 +132,45 @@ def test_print_filter_expression(filter_expr: FilterExpression, expected_output:
     "filter_expr, pyarrow_expected_expr, astra_expected_expr",
     [
         (
-            (
-                FilterField(TEST_ENTITY_SCHEMA.col_d).isin(
-                    [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                        "5",
-                        "6",
-                        "7",
-                        "8",
-                        "9",
-                        "10",
-                        "11",
-                        "12",
-                        "13",
-                        "14",
-                        "15",
-                        "16",
-                        "17",
-                        "18",
-                        "19",
-                        "20",
-                        "21",
-                        "22",
-                        "23",
-                        "24",
-                        "25",
-                        "26",
-                        "27",
-                    ]
-                )
-            ),
+            (FilterField(TEST_ENTITY_SCHEMA.col_d).isin([str(i) for i in range(1, 28)])),
             (
                 (
-                    pyarrow_field("col_d").isin(
-                        ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"]
-                    )
-                    | pyarrow_field("col_d").isin(
-                        [
-                            "15",
-                            "16",
-                            "17",
-                            "18",
-                            "19",
-                            "20",
-                            "21",
-                            "22",
-                            "23",
-                            "24",
-                            "25",
-                            "26",
-                            "27",
-                        ]
-                    )
+                    pyarrow_field("col_d").isin([str(i) for i in range(1, 15)])
+                    | pyarrow_field("col_d").isin([str(i) for i in range(15, 28)])
                 )
             ),
             (
                 [
-                    {"col_d__in": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"]},
-                    {"col_d__in": ["15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27"]},
+                    {"col_d__in": [str(i) for i in range(1, 15)]},
+                    {"col_d__in": [str(i) for i in range(15, 28)]},
                 ]
             ),
         ),
         (
+            (FilterField(TEST_ENTITY_SCHEMA.col_d).isin([str(i) for i in range(1, 26)])),
+            ((pyarrow_field("col_d").isin([str(i) for i in range(1, 26)]))),
             (
-                FilterField(TEST_ENTITY_SCHEMA.col_d).isin(
-                    [
-                        "1",
-                        "2",
-                        "3",
-                        "4",
-                        "5",
-                        "6",
-                        "7",
-                        "8",
-                        "9",
-                        "10",
-                        "11",
-                        "12",
-                        "13",
-                        "14",
-                        "15",
-                        "16",
-                        "17",
-                        "18",
-                        "19",
-                        "20",
-                        "21",
-                        "22",
-                        "23",
-                        "24",
-                        "25",
-                    ]
-                )
+                [
+                    {"col_d__in": [str(i) for i in range(1, 26)]},
+                ]
             ),
+        ),
+        (
+            (FilterField(TEST_ENTITY_SCHEMA.col_d).isin([str(i) for i in range(1, 101)])),
             (
                 (
-                    pyarrow_field("col_d").isin(
-                        [
-                            "1",
-                            "2",
-                            "3",
-                            "4",
-                            "5",
-                            "6",
-                            "7",
-                            "8",
-                            "9",
-                            "10",
-                            "11",
-                            "12",
-                            "13",
-                            "14",
-                            "15",
-                            "16",
-                            "17",
-                            "18",
-                            "19",
-                            "20",
-                            "21",
-                            "22",
-                            "23",
-                            "24",
-                            "25",
-                        ]
-                    )
+                    pyarrow_field("col_d").isin([str(i) for i in range(1, 26)])
+                    | pyarrow_field("col_d").isin([str(i) for i in range(26, 51)])
+                    | pyarrow_field("col_d").isin([str(i) for i in range(51, 76)])
+                    | pyarrow_field("col_d").isin([str(i) for i in range(76, 101)])
                 )
             ),
             (
                 [
-                    {
-                        "col_d__in": [
-                            "1",
-                            "2",
-                            "3",
-                            "4",
-                            "5",
-                            "6",
-                            "7",
-                            "8",
-                            "9",
-                            "10",
-                            "11",
-                            "12",
-                            "13",
-                            "14",
-                            "15",
-                            "16",
-                            "17",
-                            "18",
-                            "19",
-                            "20",
-                            "21",
-                            "22",
-                            "23",
-                            "24",
-                            "25",
-                        ]
-                    },
+                    {"col_d__in": [str(i) for i in range(1, 26)]},
+                    {"col_d__in": [str(i) for i in range(26, 51)]},
+                    {"col_d__in": [str(i) for i in range(51, 76)]},
+                    {"col_d__in": [str(i) for i in range(76, 101)]},
                 ]
             ),
         ),


### PR DESCRIPTION
Closes #348 

## Scope

Implemented:
 - If values list is greater than 25 for isin() chunk the list, create IN filters for each chunk and create Expression combining sub-filters with an OR operation

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
