### PR TITLE
Add support for downloading single file from ADLS

### DIFF
--- a/adapta/storage/blob/README.md
+++ b/adapta/storage/blob/README.md
@@ -6,7 +6,8 @@ This module contains storage clients for various cloud/hybrid platforms. Base cl
 
 In order to init a storage client, you need a respective authentication provider (`SecurityClient`) and a data path:
 
-### Azure example
+### Azure examples
+#### Read multiple blobs into a pandas Dataframe:
 ```python
 import pandas
 from adapta.security.clients import AzureClient
@@ -27,6 +28,27 @@ non_partitioned_parquet_table: pandas.DataFrame = pandas.concat(azure_storage_cl
     serialization_format=DataFrameParquetSerializationFormat,
     filter_predicate=lambda b: b.name.endswith('.parquet')  # Ignore non-parquet files that might be present in a folder
 ))
+```
+
+#### Download a single blob:
+```python
+from adapta.security.clients import AzureClient
+from adapta.storage.models.azure import AdlsGen2Path
+from adapta.storage.blob.azure_storage_client import AzureStorageClient
+
+azure_client = AzureClient()
+adls_path = AdlsGen2Path.from_hdfs_path('abfss://container@account.dfs.core.windows.net/path/to/my/folder/file_name')
+
+# init azure storage client
+azure_storage_client = AzureStorageClient(base_client=azure_client, path=adls_path)
+
+# download a file from Azure Storage to local path
+local_path = "/local/path"
+azure_storage_client.download_blob(adls_path, local_path)
+```
+Showing downloaded file in terminal
+```commandline
+cat /local/path/file_name
 ```
 
 ### AWS example

--- a/adapta/storage/blob/azure_storage_client.py
+++ b/adapta/storage/blob/azure_storage_client.py
@@ -170,6 +170,28 @@ class AzureStorageClient(StorageClient):
 
                 yield serialization_format().deserialize(blob_data)
 
+    def download_blob(
+        self,
+        blob_path: DataPath,
+        local_path: str,
+    ) -> None:
+        """
+        Download a blob from ADLS
+        """
+        blobs_on_path, azure_path = self._list_blobs(blob_path)
+        blob_on_path = [blob for blob in blobs_on_path][0]
+
+        os.makedirs(local_path, exist_ok=True)
+        with open(os.path.join(local_path, blob_on_path.name.split("/")[-1]), "wb") as downloaded_blob:
+            downloaded_blob.write(
+                self._blob_service_client.get_blob_client(
+                    container=azure_path.container,
+                    blob=blob_on_path.name,
+                )
+                .download_blob()
+                .readall()
+            )
+
     def download_blobs(
         self,
         blob_path: DataPath,

--- a/adapta/storage/blob/azure_storage_client.py
+++ b/adapta/storage/blob/azure_storage_client.py
@@ -175,6 +175,7 @@ class AzureStorageClient(StorageClient):
         blob_path: DataPath,
         local_path: str,
     ) -> None:
+        """Download a file from ADLS"""
         azure_path = cast_path(blob_path)
 
         os.makedirs(local_path, exist_ok=True)

--- a/adapta/storage/blob/azure_storage_client.py
+++ b/adapta/storage/blob/azure_storage_client.py
@@ -175,18 +175,14 @@ class AzureStorageClient(StorageClient):
         blob_path: DataPath,
         local_path: str,
     ) -> None:
-        """
-        Download a blob from ADLS
-        """
-        blobs_on_path, azure_path = self._list_blobs(blob_path)
-        blob_on_path = list(blobs_on_path)[0]
+        azure_path = cast_path(blob_path)
 
         os.makedirs(local_path, exist_ok=True)
-        with open(os.path.join(local_path, blob_on_path.name.split("/")[-1]), "wb") as downloaded_blob:
+        with open(os.path.join(local_path, azure_path.path.split("/")[-1]), "wb") as downloaded_blob:
             downloaded_blob.write(
                 self._blob_service_client.get_blob_client(
                     container=azure_path.container,
-                    blob=blob_on_path.name,
+                    blob=azure_path.path,
                 )
                 .download_blob()
                 .readall()

--- a/adapta/storage/blob/azure_storage_client.py
+++ b/adapta/storage/blob/azure_storage_client.py
@@ -179,7 +179,7 @@ class AzureStorageClient(StorageClient):
         Download a blob from ADLS
         """
         blobs_on_path, azure_path = self._list_blobs(blob_path)
-        blob_on_path = [blob for blob in blobs_on_path][0]
+        blob_on_path = list(blobs_on_path)[0]
 
         os.makedirs(local_path, exist_ok=True)
         with open(os.path.join(local_path, blob_on_path.name.split("/")[-1]), "wb") as downloaded_blob:

--- a/tests/test_azure_storage_client.py
+++ b/tests/test_azure_storage_client.py
@@ -15,7 +15,6 @@
 
 import os
 import tempfile
-from typing import List
 from unittest.mock import patch, MagicMock
 
 from azure.storage.blob import BlobProperties
@@ -23,31 +22,6 @@ from azure.storage.blob import BlobProperties
 from adapta.storage.blob.azure_storage_client import AzureStorageClient
 from adapta.storage.models.azure import AdlsGen2Path
 from adapta.security.clients import AzureClient
-
-
-def mock_setup_and_get_storage_client(
-    mock_client: MagicMock,
-    mock_blob_service_client: MagicMock,
-    mock_blob: MagicMock,
-    mock_container_client: MagicMock,
-    blobs_properties: List[BlobProperties],
-    data_path: AdlsGen2Path,
-) -> AzureStorageClient:
-    mock_client_instance: AzureClient = mock_client.return_value
-    mock_client_instance.connect_storage.return_value = {
-        "AZURE_STORAGE_ACCOUNT_NAME": "test",
-        "AZURE_STORAGE_ACCOUNT_KEY": "test",
-    }
-
-    azure_storage_client = AzureStorageClient(base_client=mock_client_instance, path=data_path)
-    azure_storage_client._blob_service_client = mock_blob_service_client
-
-    mock_blob_service_client.account_name = "account"
-    mock_blob_service_client.get_blob_client.return_value = mock_blob
-    mock_blob_service_client.get_container_client.return_value = mock_container_client
-    mock_container_client.list_blobs.return_value = blobs_properties
-
-    return azure_storage_client
 
 
 @patch("azure.storage.blob._download.StorageStreamDownloader")
@@ -63,52 +37,28 @@ def test_download_blobs(
     mock_downloader: MagicMock,
 ):
     test_path = f"{tempfile.gettempdir()}/test_download_blobs"
-
+    mock_client_instance: AzureClient = mock_client.return_value
     data_path = AdlsGen2Path.from_hdfs_path("abfss://container@account.dfs.core.windows.net/folder")
-    azure_storage_client = mock_setup_and_get_storage_client(
-        mock_client,
-        mock_blob_service_client,
-        mock_blob,
-        mock_container_client,
-        [BlobProperties(**{"name": f"test{i}", "Content-Length": 1}) for i in range(10)],
-        data_path,
-    )
+    mock_client_instance.connect_storage.return_value = {
+        "AZURE_STORAGE_ACCOUNT_NAME": "test",
+        "AZURE_STORAGE_ACCOUNT_KEY": "test",
+    }
+
+    azure_storage_client = AzureStorageClient(base_client=mock_client_instance, path=data_path)
+
+    azure_storage_client._blob_service_client = mock_blob_service_client
+    mock_blob_service_client.account_name = "account"
+    mock_blob_service_client.get_blob_client.return_value = mock_blob
+    mock_blob_service_client.get_container_client.return_value = mock_container_client
+    mock_container_client.list_blobs.return_value = [
+        BlobProperties(**{"name": f"test{i}", "Content-Length": 1}) for i in range(10)
+    ]
 
     mock_blob.download_blob = mock_downloader
     mock_downloader.return_value.readall.return_value = b""
+
     azure_storage_client.download_blobs(blob_path=data_path, local_path=test_path, threads=3)
 
     file_count = len(os.listdir(test_path))
 
     assert file_count == 10
-
-
-@patch("azure.storage.blob._download.StorageStreamDownloader")
-@patch("azure.storage.blob.BlobClient")
-@patch("azure.storage.blob.ContainerClient")
-@patch("azure.storage.blob.BlobServiceClient")
-@patch("adapta.security.clients.AzureClient")
-def test_download_blob(
-    mock_client: MagicMock,
-    mock_blob_service_client: MagicMock,
-    mock_container_client: MagicMock,
-    mock_blob: MagicMock,
-    mock_downloader: MagicMock,
-):
-    test_path = f"{tempfile.gettempdir()}/test_download_blob"
-
-    data_path = AdlsGen2Path.from_hdfs_path("abfss://container@account.dfs.core.windows.net/folder/file_name")
-    azure_storage_client = mock_setup_and_get_storage_client(
-        mock_client,
-        mock_blob_service_client,
-        mock_blob,
-        mock_container_client,
-        [BlobProperties(**{"name": "/folder/file_name", "Content-Length": 1})],
-        data_path,
-    )
-
-    mock_blob.download_blob = mock_downloader
-    mock_downloader.return_value.readall.return_value = b""
-    azure_storage_client.download_blob(blob_path=data_path, local_path=test_path)
-
-    assert os.path.isfile(f"{test_path}/file_name")

--- a/tests/test_azure_storage_client.py
+++ b/tests/test_azure_storage_client.py
@@ -15,6 +15,7 @@
 
 import os
 import tempfile
+from typing import List
 from unittest.mock import patch, MagicMock
 
 from azure.storage.blob import BlobProperties
@@ -22,6 +23,31 @@ from azure.storage.blob import BlobProperties
 from adapta.storage.blob.azure_storage_client import AzureStorageClient
 from adapta.storage.models.azure import AdlsGen2Path
 from adapta.security.clients import AzureClient
+
+
+def mock_setup_and_get_storage_client(
+    mock_client: MagicMock,
+    mock_blob_service_client: MagicMock,
+    mock_blob: MagicMock,
+    mock_container_client: MagicMock,
+    blobs_properties: List[BlobProperties],
+    data_path: AdlsGen2Path,
+) -> AzureStorageClient:
+    mock_client_instance: AzureClient = mock_client.return_value
+    mock_client_instance.connect_storage.return_value = {
+        "AZURE_STORAGE_ACCOUNT_NAME": "test",
+        "AZURE_STORAGE_ACCOUNT_KEY": "test",
+    }
+
+    azure_storage_client = AzureStorageClient(base_client=mock_client_instance, path=data_path)
+    azure_storage_client._blob_service_client = mock_blob_service_client
+
+    mock_blob_service_client.account_name = "account"
+    mock_blob_service_client.get_blob_client.return_value = mock_blob
+    mock_blob_service_client.get_container_client.return_value = mock_container_client
+    mock_container_client.list_blobs.return_value = blobs_properties
+
+    return azure_storage_client
 
 
 @patch("azure.storage.blob._download.StorageStreamDownloader")
@@ -37,28 +63,52 @@ def test_download_blobs(
     mock_downloader: MagicMock,
 ):
     test_path = f"{tempfile.gettempdir()}/test_download_blobs"
-    mock_client_instance: AzureClient = mock_client.return_value
+
     data_path = AdlsGen2Path.from_hdfs_path("abfss://container@account.dfs.core.windows.net/folder")
-    mock_client_instance.connect_storage.return_value = {
-        "AZURE_STORAGE_ACCOUNT_NAME": "test",
-        "AZURE_STORAGE_ACCOUNT_KEY": "test",
-    }
-
-    azure_storage_client = AzureStorageClient(base_client=mock_client_instance, path=data_path)
-
-    azure_storage_client._blob_service_client = mock_blob_service_client
-    mock_blob_service_client.account_name = "account"
-    mock_blob_service_client.get_blob_client.return_value = mock_blob
-    mock_blob_service_client.get_container_client.return_value = mock_container_client
-    mock_container_client.list_blobs.return_value = [
-        BlobProperties(**{"name": f"test{i}", "Content-Length": 1}) for i in range(10)
-    ]
+    azure_storage_client = mock_setup_and_get_storage_client(
+        mock_client,
+        mock_blob_service_client,
+        mock_blob,
+        mock_container_client,
+        [BlobProperties(**{"name": f"test{i}", "Content-Length": 1}) for i in range(10)],
+        data_path,
+    )
 
     mock_blob.download_blob = mock_downloader
     mock_downloader.return_value.readall.return_value = b""
-
     azure_storage_client.download_blobs(blob_path=data_path, local_path=test_path, threads=3)
 
     file_count = len(os.listdir(test_path))
 
     assert file_count == 10
+
+
+@patch("azure.storage.blob._download.StorageStreamDownloader")
+@patch("azure.storage.blob.BlobClient")
+@patch("azure.storage.blob.ContainerClient")
+@patch("azure.storage.blob.BlobServiceClient")
+@patch("adapta.security.clients.AzureClient")
+def test_download_blob(
+    mock_client: MagicMock,
+    mock_blob_service_client: MagicMock,
+    mock_container_client: MagicMock,
+    mock_blob: MagicMock,
+    mock_downloader: MagicMock,
+):
+    test_path = f"{tempfile.gettempdir()}/test_download_blob"
+
+    data_path = AdlsGen2Path.from_hdfs_path("abfss://container@account.dfs.core.windows.net/folder/file_name")
+    azure_storage_client = mock_setup_and_get_storage_client(
+        mock_client,
+        mock_blob_service_client,
+        mock_blob,
+        mock_container_client,
+        [BlobProperties(**{"name": "/folder/file_name", "Content-Length": 1})],
+        data_path,
+    )
+
+    mock_blob.download_blob = mock_downloader
+    mock_downloader.return_value.readall.return_value = b""
+    azure_storage_client.download_blob(blob_path=data_path, local_path=test_path)
+
+    assert os.path.isfile(f"{test_path}/file_name")


### PR DESCRIPTION
Closes #371 

## Scope

Implemented:
 - Added `download_blob` in `AzureStorageClient` for downloading files instead of folder

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [x] Review requested on `latest` commit.
