### PR TITLE
Add documentation of xmltree_to_dict_collection

### DIFF
--- a/adapta/utils/README.md
+++ b/adapta/utils/README.md
@@ -156,3 +156,55 @@ semantic_logger = SemanticLogger().add_log_source(log_source_name='test_logger_1
 adder(5, 4, logger=semantic_logger, metrics_provider=provider, metric_tags=datadog_tags)
 upgrade_message('Lorum Ipsum', logger=semantic_logger, metrics_provider=provider, metric_tags=datadog_tags)
 ```
+
+## xmltree_to_dict_collection
+This function is used to convert a XML source (supports both xml file and string) to a list of objects.
+
+Parameters:
+* `xml_source`: A valid XML string or a path to a valid XML file
+* `node_type`: The type of each element in returned list, like `dict` or a class inheriting from `DataClassJsonMixin`
+
+Example Usage:
+
+* When input is a XML file, with path `/path/to/my/file`, and `node_type` is `dict`
+```xml
+<?xml version="1.0"?>
+<!-- Content of /path/to/my/file -->
+<catalog>
+   <book>book_name1</book>
+   <book>book_name2</book>
+</catalog>
+```
+```python
+from pathlib import Path
+from adapta.utils import xmltree_to_dict_collection
+
+file_path = Path("/path/to/my/file")
+converted_result = xmltree_to_dict_collection(file_path, dict)
+print(converted_result)
+```
+Output:
+```
+[{'book': 'book_name1'}, {'book': 'book_name2'}]
+```
+* When input is a XML string and `node_type` is a customized class
+```python
+from dataclasses import dataclass
+from adapta.utils import xmltree_to_dict_collection
+from dataclasses_json import DataClassJsonMixin
+
+@dataclass
+class ExampleNodeType(DataClassJsonMixin):
+    """
+    A node type example
+    """
+    book: str
+
+xml_str = "<?xml version='1.0'?><catalog><book>book_name1</book><book>book_name2</book></catalog>"
+converted_result = xmltree_to_dict_collection(xml_str, ExampleNodeType)
+print(converted_result)
+```
+Output:
+```
+[ExampleNodeType(book='book_name1'), ExampleNodeType(book='book_name2')]
+```


### PR DESCRIPTION
Closes #373 

## Scope

Implemented:
 - Added documentation of `xmltree_to_dict_collection` in `README`

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
