### PR TITLE
Auto infer threadcount for Astra

### DIFF
--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -245,7 +245,7 @@ class AstraClient:
         :param: partition_keys: An optional list of columns that constitute a partition key, if it cannot be inferred from is_partition_key metadata on a dataclass field.
         :param: custom_indexes: An optional list of custom indexes, if it cannot be inferred from is_custom_index on a dataclass field.
         :param: deduplicate: Optionally deduplicate query result, for example when only the partition key part of a primary key is used to fetch results.
-        :param: num_threads: Optionally run filtering using multiple threads.
+        :param: num_threads: Optionally run filtering using multiple threads. Setting this to -1 will cause this method to automatically evaluate number of threads based on filter expression size.
         """
 
         @backoff.on_exception(
@@ -305,7 +305,12 @@ class AstraClient:
         )
 
         if num_threads:
-            with ThreadPoolExecutor(max_workers=num_threads) as tpe:
+            max_threads = (
+                max([len(compiled_filter_values) // 2, num_threads, os.cpu_count()])
+                if num_threads == -1
+                else num_threads
+            )
+            with ThreadPoolExecutor(max_workers=max_threads) as tpe:
                 result = pandas.concat(
                     tpe.map(
                         lambda args: to_pandas(*args),

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -22,6 +22,7 @@ import dataclasses
 import datetime
 import enum
 import logging
+import math
 import os
 import platform
 import re
@@ -306,7 +307,7 @@ class AstraClient:
 
         if num_threads:
             max_threads = (
-                max([len(compiled_filter_values) // 2, num_threads, os.cpu_count()])
+                max([int(math.sqrt(len(compiled_filter_values) + 1) / 2), num_threads, os.cpu_count()])
                 if num_threads == -1
                 else num_threads
             )

--- a/adapta/storage/query_enabled_store/_qes_astra.py
+++ b/adapta/storage/query_enabled_store/_qes_astra.py
@@ -80,6 +80,7 @@ class AstraQueryEnabledStore(QueryEnabledStore[AstraCredential, AstraSettings]):
                 key_column_filter_values=filter_expression,
                 table_name=astra_path.table,
                 select_columns=columns,
+                num_threads=-1,  # auto-infer, see method documentation
             )
 
     def _apply_query(self, query: str) -> Union[pandas.DataFrame, Iterator[pandas.DataFrame]]:


### PR DESCRIPTION
Closes #339

## Scope

Implemented:
 - Allowed to enable auto-infer as a max of [half of filtering array size, cpu_count] if num_threads is set to -1

Additional changes:
- Updated QES for Astra to always use auto-infer

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.

