### PR TITLE
Update license years and refactor DataPath-Client relation a bit

### DIFF
--- a/adapta/__init__.py
+++ b/adapta/__init__.py
@@ -2,7 +2,7 @@
  Global index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/_version.py
+++ b/adapta/_version.py
@@ -2,7 +2,7 @@
  Package version.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/connectors/__init__.py
+++ b/adapta/connectors/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/connectors/service_bus/__init__.py
+++ b/adapta/connectors/service_bus/__init__.py
@@ -1,6 +1,6 @@
 """init file"""
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/connectors/service_bus/_connector.py
+++ b/adapta/connectors/service_bus/_connector.py
@@ -1,7 +1,7 @@
 """
     Connector for Azure Service Bus.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/__init__.py
+++ b/adapta/logs/__init__.py
@@ -1,7 +1,7 @@
 """
  Module index.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/_async_logger.py
+++ b/adapta/logs/_async_logger.py
@@ -1,7 +1,7 @@
 """
  Asyncio-safe implementation of a Semantic Logger.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/_async_logger.py
+++ b/adapta/logs/_async_logger.py
@@ -125,13 +125,25 @@ class _AsyncLogger(Generic[TLogger], _InternalLogger):
             template=template, logger=self._logger, tags=tags, exception=exception, diagnostics=diagnostics, **kwargs
         )
 
-    def __enter__(self):
+    def start(self):
+        """
+        Starts the async listener.
+        """
         self._listener = QueueListener(self._logger_message_queue, *self._log_handlers, respect_handler_level=True)
         self._listener.start()
+
+    def stop(self):
+        """
+        Stops the async listener and flushes the buffer out to all handlers.
+        """
+        self._listener.stop()
+
+    def __enter__(self):
+        self.start()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._listener.stop()
+        self.stop()
 
 
 def create_async_logger(

--- a/adapta/logs/_base.py
+++ b/adapta/logs/_base.py
@@ -1,7 +1,7 @@
 """
  Adapta Logging Interface.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/_internal.py
+++ b/adapta/logs/_internal.py
@@ -1,5 +1,5 @@
 """Classes for internal use by `adapta.logs` module. Should not be imported outside this module"""
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/_internal_logger.py
+++ b/adapta/logs/_internal_logger.py
@@ -1,7 +1,7 @@
 """
  Shared functionality for the MetadataLogger enricher implementations.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/handlers/__init__.py
+++ b/adapta/logs/handlers/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/handlers/datadog_api_handler.py
+++ b/adapta/logs/handlers/datadog_api_handler.py
@@ -1,7 +1,7 @@
 """
   Logging handler for DataDog.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/handlers/safe_stream_handler.py
+++ b/adapta/logs/handlers/safe_stream_handler.py
@@ -1,7 +1,7 @@
 """
 Logging handler for Stdout that does not create duplicates if stdout redirection is used
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/models/__init__.py
+++ b/adapta/logs/models/__init__.py
@@ -2,7 +2,7 @@
  Module index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/models/_log_level.py
+++ b/adapta/logs/models/_log_level.py
@@ -1,7 +1,7 @@
 """
  Standard log levels.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/logs/models/_logs_metadata.py
+++ b/adapta/logs/models/_logs_metadata.py
@@ -2,7 +2,7 @@
 Models for log messages
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/metrics/__init__.py
+++ b/adapta/metrics/__init__.py
@@ -2,7 +2,7 @@
  Import index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/metrics/_base.py
+++ b/adapta/metrics/_base.py
@@ -1,7 +1,7 @@
 """
  Metrics integration abstraction.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/metrics/providers/__init__.py
+++ b/adapta/metrics/providers/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/metrics/providers/datadog_provider.py
+++ b/adapta/metrics/providers/datadog_provider.py
@@ -1,7 +1,7 @@
 """
   Implementation of a metrics provider for Datadog.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/ml/__init__.py
+++ b/adapta/ml/__init__.py
@@ -1,7 +1,7 @@
 """
  Import index.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/ml/_model.py
+++ b/adapta/ml/_model.py
@@ -1,5 +1,5 @@
 """Machine learning model module"""
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/ml/mlflow/__init__.py
+++ b/adapta/ml/mlflow/__init__.py
@@ -1,5 +1,5 @@
 """Import index"""
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -1,7 +1,7 @@
 """
   Thin wrapper for Mlflow operations.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/ml/mlflow/_functions.py
+++ b/adapta/ml/mlflow/_functions.py
@@ -1,5 +1,5 @@
 """Mlflow python model module"""
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/process_communication/__init__.py
+++ b/adapta/process_communication/__init__.py
@@ -2,7 +2,7 @@
  Import index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/process_communication/_models.py
+++ b/adapta/process_communication/_models.py
@@ -1,7 +1,7 @@
 """
   Models used for inter-process communication in data processing applications.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ from typing import Optional, List, Iterable
 
 from dataclasses_json import DataClassJsonMixin
 
+from adapta.storage.models import parse_data_path
 from adapta.storage.models.astra import AstraPath
 from adapta.storage.models.base import DataPath
 from adapta.storage.models.azure import AdlsGen2Path, WasbPath
@@ -61,13 +62,7 @@ class DataSocket(DataClassJsonMixin):
 
         :return:
         """
-        for candidate in candidates:
-            try:
-                return candidate.from_hdfs_path(self.data_path)
-            except:  # pylint: disable=W0702
-                continue
-
-        return None
+        return parse_data_path(self.data_path, candidates=candidates)
 
     def serialize(self) -> str:
         """

--- a/adapta/schema_management/__init__.py
+++ b/adapta/schema_management/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/schema_management/schema_entity.py
+++ b/adapta/schema_management/schema_entity.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/__init__.py
+++ b/adapta/security/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/__init__.py
+++ b/adapta/security/clients/__init__.py
@@ -2,7 +2,7 @@
  Import index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/_azure_client.py
+++ b/adapta/security/clients/_azure_client.py
@@ -1,7 +1,7 @@
 """
  Azure Cloud implementation of AuthenticationClient.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/_base.py
+++ b/adapta/security/clients/_base.py
@@ -1,7 +1,7 @@
 """
  Base client for all infrastructure providers.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/_local_client.py
+++ b/adapta/security/clients/_local_client.py
@@ -1,7 +1,7 @@
 """
  Client representing Local infrastructure. Mainly used for unit tests.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/aws/__init__.py
+++ b/adapta/security/clients/aws/__init__.py
@@ -1,7 +1,7 @@
 """
 Import index
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/aws/_aws_client.py
+++ b/adapta/security/clients/aws/_aws_client.py
@@ -1,7 +1,7 @@
 """
  Amazon Web Services implementation of AuthenticationClient.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/aws/_aws_credentials.py
+++ b/adapta/security/clients/aws/_aws_credentials.py
@@ -1,7 +1,7 @@
 """
 Contains credentials provider for AWS clients
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/hashicorp_vault/__init__.py
+++ b/adapta/security/clients/hashicorp_vault/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/hashicorp_vault/hashicorp_vault_client.py
+++ b/adapta/security/clients/hashicorp_vault/hashicorp_vault_client.py
@@ -1,7 +1,7 @@
 """
  Hashicorp Vault implementation of AuthenticationClient.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/hashicorp_vault/kubernetes_client.py
+++ b/adapta/security/clients/hashicorp_vault/kubernetes_client.py
@@ -1,7 +1,7 @@
 """
  Hashicorp Vault implementation of AuthenticationClient.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/hashicorp_vault/oidc_client.py
+++ b/adapta/security/clients/hashicorp_vault/oidc_client.py
@@ -1,7 +1,7 @@
 """
  Hashicorp Vault implementation of AuthenticationClient.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/security/clients/hashicorp_vault/token_client.py
+++ b/adapta/security/clients/hashicorp_vault/token_client.py
@@ -1,7 +1,7 @@
 """
  Hashicorp Vault implementation of AuthenticationClient.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/__init__.py
+++ b/adapta/storage/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/blob/__init__.py
+++ b/adapta/storage/blob/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/blob/azure_storage_client.py
+++ b/adapta/storage/blob/azure_storage_client.py
@@ -34,7 +34,6 @@ from azure.storage.blob import (
     ContainerClient,
 )
 
-from adapta.process_communication import DataSocket
 from adapta.storage.blob.base import StorageClient
 from adapta.security.clients import AzureClient
 from adapta.storage.models import parse_data_path

--- a/adapta/storage/blob/azure_storage_client.py
+++ b/adapta/storage/blob/azure_storage_client.py
@@ -1,7 +1,7 @@
 """
  Storage Client implementation for Azure Cloud.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -34,8 +34,10 @@ from azure.storage.blob import (
     ContainerClient,
 )
 
+from adapta.process_communication import DataSocket
 from adapta.storage.blob.base import StorageClient
 from adapta.security.clients import AzureClient
+from adapta.storage.models import parse_data_path
 from adapta.storage.models.azure import AdlsGen2Path, WasbPath, cast_path
 from adapta.storage.models.base import DataPath
 from adapta.storage.models.format import SerializationFormat
@@ -76,6 +78,14 @@ class AzureStorageClient(StorageClient):
             self._blob_service_client: BlobServiceClient = BlobServiceClient.from_connection_string(
                 connection_string, retry_policy=retry_policy
             )
+
+    @classmethod
+    def for_storage_path(cls, path: str) -> "AzureStorageClient":
+        """
+        Generate client instance that can operate on the provided path
+        """
+        azure_path = cast_path(parse_data_path(path))
+        return cls(base_client=AzureClient(), path=azure_path)
 
     def _get_blob_client(self, blob_path: DataPath) -> BlobClient:
         azure_path = cast_path(blob_path)

--- a/adapta/storage/blob/base.py
+++ b/adapta/storage/blob/base.py
@@ -1,7 +1,7 @@
 """
  Abstraction for storage operations.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -149,4 +149,11 @@ class StorageClient(ABC):
         :param blob_path: Path to source blob.
         :param target_blob_path: Path to target blob.
         :param doze_period_ms: number of ms to doze between polling the status of the copy.
+        """
+
+    @classmethod
+    @abstractmethod
+    def for_storage_path(cls, path: str) -> "StorageClient":
+        """
+        Create client instance that can operate on the provided path
         """

--- a/adapta/storage/blob/s3_storage_client.py
+++ b/adapta/storage/blob/s3_storage_client.py
@@ -1,7 +1,7 @@
 """
  Storage Client implementation for AWS S3.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ from typing import Optional, Callable, Type, Iterator, Dict, TypeVar
 from adapta.security.clients import AwsClient
 from adapta.storage.blob.base import StorageClient
 from adapta.storage.exceptions import StorageClientError
+from adapta.storage.models import parse_data_path
 from adapta.storage.models.aws import cast_path
 from adapta.storage.models.base import DataPath
 from adapta.storage.models.format import SerializationFormat
@@ -139,3 +140,11 @@ class S3StorageClient(StorageClient, ABC):
         Not implemented in S3 Client
         """
         raise NotImplementedError("Not implemented in S3StorageClient")
+
+    @classmethod
+    def for_storage_path(cls, path: str) -> "S3StorageClient":
+        """
+        Generate client instance that can operate on the provided path. Always uses EnvironmentCredentials/
+        """
+        _ = cast_path(parse_data_path(path))
+        return cls(base_client=AwsClient())

--- a/adapta/storage/cache/__init__.py
+++ b/adapta/storage/cache/__init__.py
@@ -2,7 +2,7 @@
   Import index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/cache/_base.py
+++ b/adapta/storage/cache/_base.py
@@ -1,7 +1,7 @@
 """
   Generic key-value cache.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/cache/redis_cache.py
+++ b/adapta/storage/cache/redis_cache.py
@@ -1,7 +1,7 @@
 """
   Key-value cache based on Redis.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/database/__init__.py
+++ b/adapta/storage/database/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/database/azure_sql.py
+++ b/adapta/storage/database/azure_sql.py
@@ -2,7 +2,7 @@
  ODBC client extension for Azure SQL.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/database/models/__init__.py
+++ b/adapta/storage/database/models/__init__.py
@@ -1,7 +1,7 @@
 """
  Import index.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/database/models/_models.py
+++ b/adapta/storage/database/models/_models.py
@@ -1,7 +1,7 @@
 """
   Models for relational database clients.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/database/odbc.py
+++ b/adapta/storage/database/odbc.py
@@ -2,7 +2,7 @@
  Database client that uses an ODBC driver.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/database/trino_sql.py
+++ b/adapta/storage/database/trino_sql.py
@@ -2,7 +2,7 @@
   SqlAlchemy-based Trino Client Wrapper
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/delta_lake/__init__.py
+++ b/adapta/storage/delta_lake/__init__.py
@@ -1,7 +1,7 @@
 """
  Import index.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/delta_lake/_functions.py
+++ b/adapta/storage/delta_lake/_functions.py
@@ -1,7 +1,7 @@
 """
  Operations on Delta Lake tables.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/delta_lake/_models.py
+++ b/adapta/storage/delta_lake/_models.py
@@ -1,7 +1,7 @@
 """
  Models used by delta lake functions.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/distributed_object_store/__init__.py
+++ b/adapta/storage/distributed_object_store/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/distributed_object_store/datastax_astra/__init__.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/datastax_astra/astra_client.py
@@ -2,7 +2,7 @@
  DataStax Astra client driver.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/exceptions.py
+++ b/adapta/storage/exceptions.py
@@ -3,7 +3,7 @@ Storage client exceptions
 """
 
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/models/__init__.py
+++ b/adapta/storage/models/__init__.py
@@ -1,3 +1,6 @@
+"""
+ Module index.
+"""
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/adapta/storage/models/__init__.py
+++ b/adapta/storage/models/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,3 +12,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+
+from adapta.storage.models._functions import *

--- a/adapta/storage/models/_functions.py
+++ b/adapta/storage/models/_functions.py
@@ -1,0 +1,46 @@
+"""
+ Models used by Astra DB when working with storage.
+"""
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from typing import Iterable, Optional
+
+from adapta.storage.models.astra import AstraPath
+from adapta.storage.models.aws import S3Path
+from adapta.storage.models.azure import AdlsGen2Path, WasbPath
+from adapta.storage.models.base import DataPath
+from adapta.storage.models.local import LocalPath
+
+
+def parse_data_path(
+    path: str, candidates: Iterable[DataPath] = (AdlsGen2Path, LocalPath, WasbPath, AstraPath, S3Path)
+) -> Optional[DataPath]:
+    """
+      Attempts to convert a string path to one of the known DataPath types.
+
+    :param path: A path to convert
+    :param candidates: Conversion candidate classes for `DataPath`. Default to all currently supported `DataPath` implementations.
+      If a user has their own `DataPath` implementations, those can be supplied instead for convenience.
+
+    :return:
+    """
+    for candidate in candidates:
+        try:
+            return candidate.from_hdfs_path(path)
+        except:  # pylint: disable=W0702
+            continue
+
+    return None

--- a/adapta/storage/models/astra.py
+++ b/adapta/storage/models/astra.py
@@ -1,7 +1,7 @@
 """
  Models used by Astra DB when working with storage.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/models/aws.py
+++ b/adapta/storage/models/aws.py
@@ -1,7 +1,7 @@
 """
  Models used by AWS when working with storage.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/models/azure.py
+++ b/adapta/storage/models/azure.py
@@ -1,7 +1,7 @@
 """
  Models used by Azure Client when working with storage.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/models/base.py
+++ b/adapta/storage/models/base.py
@@ -1,7 +1,7 @@
 """
  Base class representing file system path.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/models/format.py
+++ b/adapta/storage/models/format.py
@@ -1,7 +1,7 @@
 """
 Serialization formats for saving data structures as blob.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/models/hive.py
+++ b/adapta/storage/models/hive.py
@@ -1,7 +1,7 @@
 """
  Models used by Hive storages.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/models/local.py
+++ b/adapta/storage/models/local.py
@@ -1,7 +1,7 @@
 """
  Models used by Local Client when working with storage.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/query_enabled_store/__init__.py
+++ b/adapta/storage/query_enabled_store/__init__.py
@@ -1,7 +1,7 @@
 """
  Import index.
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/query_enabled_store/_models.py
+++ b/adapta/storage/query_enabled_store/_models.py
@@ -2,7 +2,7 @@
  Query Enabled Store Connection interface.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/secrets/__init__.py
+++ b/adapta/storage/secrets/__init__.py
@@ -2,7 +2,7 @@
  Import index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/secrets/_base.py
+++ b/adapta/storage/secrets/_base.py
@@ -2,7 +2,7 @@
  Abstraction for secret storage operations.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/secrets/azure_secret_client.py
+++ b/adapta/storage/secrets/azure_secret_client.py
@@ -1,7 +1,7 @@
 """
  Azure Secret Storage Client (KeyVault).
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/storage/secrets/hashicorp_vault_secret_storage_client.py
+++ b/adapta/storage/secrets/hashicorp_vault_secret_storage_client.py
@@ -1,7 +1,7 @@
 """
  Hashicorp Vault Secret storage client
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/utils/__init__.py
+++ b/adapta/utils/__init__.py
@@ -2,7 +2,7 @@
  Utilities module index.
 """
 
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/utils/_common.py
+++ b/adapta/utils/_common.py
@@ -1,5 +1,5 @@
 """Common utility functions. All of these are imported into __init__.py"""
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/adapta/utils/concurrent_task_runner.py
+++ b/adapta/utils/concurrent_task_runner.py
@@ -1,7 +1,7 @@
 """
  Models used by utility methods
 """
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_astra.py
+++ b/tests/test_astra.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_azure_storage_client.py
+++ b/tests/test_azure_storage_client.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_delta_history.py
+++ b/tests/test_delta_history.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_delta_load.py
+++ b/tests/test_delta_load.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_hive.py
+++ b/tests/test_hive.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_process_communication.py
+++ b/tests/test_process_communication.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_safe_stream_handler.py
+++ b/tests/test_safe_stream_handler.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_serialization_format.py
+++ b/tests/test_serialization_format.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_storage_databases_odbc.py
+++ b/tests/test_storage_databases_odbc.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/tests/test_vault_client.py
+++ b/tests/test_vault_client.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023. ECCO Sneaks & Data
+#  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/esd-services-api-client/issues/83

## Scope

Implemented:
 - Added `for_storage_path` method to our storage client implementations. This is needed for generalisation of storage client provisioning

Additional changes:
- Moved `parse_data_path` core logic to a static method. `DataSocket` now simply reuses it.
- Updated licensing years

## Checklist

- [x] GitHub issue exists for this change.
