### PR TITLE
Enable interchangeability between SemanticLogger and AsyncLogger

### DIFF
--- a/adapta/logs/_internal_logger.py
+++ b/adapta/logs/_internal_logger.py
@@ -18,12 +18,14 @@
 
 
 import logging
+from abc import ABC
 from typing import Optional, Dict
 
 from adapta.logs._internal import MetadataLogger
+from adapta.logs._logger_interface import LoggerInterface
 
 
-class _InternalLogger:
+class _InternalLogger(LoggerInterface, ABC):
     def __init__(
         self,
         fixed_template: Optional[Dict[str, Dict[str, str]]] = None,

--- a/adapta/logs/_logger_interface.py
+++ b/adapta/logs/_logger_interface.py
@@ -2,6 +2,7 @@
  Marker interface for logging API
 """
 from abc import ABC, abstractmethod
+from typing import Optional, Dict
 
 
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
@@ -21,26 +22,41 @@ from abc import ABC, abstractmethod
 
 
 class LoggerInterface(ABC):
+    """
+    Abstract logger interface, enables interchangeability between sync/async loggers
+    """
+
     @abstractmethod
-    def info(self, **kwargs):
+    def info(self, template: str, tags: Optional[Dict[str, str]] = None, **kwargs):
         """
         Logs a message on INFO level
         """
 
     @abstractmethod
-    def warning(self, **kwargs):
+    def warning(
+        self, template: str, exception: Optional[BaseException] = None, tags: Optional[Dict[str, str]] = None, **kwargs
+    ):
         """
         Logs a message on WARN level
         """
 
     @abstractmethod
-    def error(self, **kwargs):
+    def error(
+        self, template: str, exception: Optional[BaseException] = None, tags: Optional[Dict[str, str]] = None, **kwargs
+    ):
         """
         Logs a message on ERROR level
         """
 
     @abstractmethod
-    def debug(self, **kwargs):
+    def debug(
+        self,
+        template: str,
+        exception: Optional[BaseException] = None,
+        diagnostics: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+        **kwargs
+    ):
         """
         Logs a message on DEBUG level
         """

--- a/adapta/logs/_logger_interface.py
+++ b/adapta/logs/_logger_interface.py
@@ -1,6 +1,9 @@
 """
- Module index.
+ Marker interface for logging API
 """
+from abc import ABC, abstractmethod
+
+
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +19,28 @@
 #  limitations under the License.
 #
 
-from adapta.logs._base import SemanticLogger
-from adapta.logs._async_logger import create_async_logger
-from adapta.logs._logger_interface import LoggerInterface
+
+class LoggerInterface(ABC):
+    @abstractmethod
+    def info(self, **kwargs):
+        """
+        Logs a message on INFO level
+        """
+
+    @abstractmethod
+    def warning(self, **kwargs):
+        """
+        Logs a message on WARN level
+        """
+
+    @abstractmethod
+    def error(self, **kwargs):
+        """
+        Logs a message on ERROR level
+        """
+
+    @abstractmethod
+    def debug(self, **kwargs):
+        """
+        Logs a message on DEBUG level
+        """


### PR DESCRIPTION
This is required to allow apps to migrate without re-writing logger interfaces