### PR TITLE
Fixes is_optional

### DIFF
--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -2,7 +2,7 @@
 import sys
 from typing import Type, get_origin, Union, get_args
 
-TypeHint = Type
+TypeHint = Type  # pylint: disable=invalid-name
 if sys.version_info >= (3, 10):
     from types import UnionType
     TypeHint = Union[UnionType, Type]

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -5,6 +5,7 @@ from typing import Type, get_origin, Union, get_args
 TypeHint = Type
 if sys.version_info >= (3, 10):
     from types import UnionType
+
     TypeHint = Union[UnionType, Type]  # pylint: disable=invalid-name
 
 

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -5,7 +5,7 @@ from typing import Type, get_origin, Union, get_args
 type_hint = Type
 if sys.version_info >= (3, 10):
     from types import UnionType
-    type_hint = Union[UnionType, Union]
+    type_hint = Union[UnionType, Type]
 
 
 def is_optional(type_: type_hint) -> bool:

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -1,5 +1,5 @@
 """Common python typing functions. All of these are imported into __init__.py"""
-
+from types import UnionType
 from typing import Type, get_origin, Union, get_args
 
 
@@ -10,4 +10,5 @@ def is_optional(type_: Type) -> bool:
     :param type_: Type to check.
     :return: True if the type is Optional, False otherwise.
     """
-    return get_origin(type_) is Union and type(None) in get_args(type_)
+    origin_type = get_origin(type_)
+    return (origin_type is Union or origin_type is UnionType) and type(None) in get_args(type_)

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -2,14 +2,14 @@
 import sys
 from typing import Type, get_origin, Union, get_args
 
-TypeHint = Type
+ArgumentType = Type
 if sys.version_info >= (3, 10):
     from types import UnionType
 
-    TypeHint = Union[UnionType, Type]  # pylint: disable=invalid-name
+    ArgumentType = Union[UnionType, Type]
 
 
-def is_optional(type_: TypeHint) -> bool:
+def is_optional(type_: ArgumentType) -> bool:
     """
     Checks if a type is Optional.
 

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -2,13 +2,13 @@
 import sys
 from typing import Type, get_origin, Union, get_args
 
-type_hint = Type
+TypeHint = Type
 if sys.version_info >= (3, 10):
     from types import UnionType
-    type_hint = Union[UnionType, Type]
+    TypeHint = Union[UnionType, Type]
 
 
-def is_optional(type_: type_hint) -> bool:
+def is_optional(type_: TypeHint) -> bool:
     """
     Checks if a type is Optional.
 
@@ -18,7 +18,6 @@ def is_optional(type_: type_hint) -> bool:
     origin_type = get_origin(type_)
 
     if sys.version_info >= (3, 10):
-        from types import UnionType
         return (origin_type is UnionType or origin_type is Union) and type(None) in get_args(type_)
 
     return origin_type is Union and type(None) in get_args(type_)

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -2,10 +2,10 @@
 import sys
 from typing import Type, get_origin, Union, get_args
 
-TypeHint = Type  # pylint: disable=invalid-name
+TypeHint = Type
 if sys.version_info >= (3, 10):
     from types import UnionType
-    TypeHint = Union[UnionType, Type]
+    TypeHint = Union[UnionType, Type]  # pylint: disable=invalid-name
 
 
 def is_optional(type_: TypeHint) -> bool:

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -1,10 +1,14 @@
 """Common python typing functions. All of these are imported into __init__.py"""
 import sys
-from types import UnionType
 from typing import Type, get_origin, Union, get_args
 
+type_hint = Type
+if sys.version_info >= (3, 10):
+    from types import UnionType
+    type_hint = Union[UnionType, Union]
 
-def is_optional(type_: Union[Type, UnionType]) -> bool:
+
+def is_optional(type_: type_hint) -> bool:
     """
     Checks if a type is Optional.
 
@@ -14,6 +18,7 @@ def is_optional(type_: Union[Type, UnionType]) -> bool:
     origin_type = get_origin(type_)
 
     if sys.version_info >= (3, 10):
+        from types import UnionType
         return (origin_type is UnionType or origin_type is Union) and type(None) in get_args(type_)
 
     return origin_type is Union and type(None) in get_args(type_)

--- a/adapta/utils/python_typing/_functions.py
+++ b/adapta/utils/python_typing/_functions.py
@@ -1,9 +1,10 @@
 """Common python typing functions. All of these are imported into __init__.py"""
+import sys
 from types import UnionType
 from typing import Type, get_origin, Union, get_args
 
 
-def is_optional(type_: Type) -> bool:
+def is_optional(type_: Union[Type, UnionType]) -> bool:
     """
     Checks if a type is Optional.
 
@@ -11,4 +12,8 @@ def is_optional(type_: Type) -> bool:
     :return: True if the type is Optional, False otherwise.
     """
     origin_type = get_origin(type_)
-    return (origin_type is Union or origin_type is UnionType) and type(None) in get_args(type_)
+
+    if sys.version_info >= (3, 10):
+        return (origin_type is UnionType or origin_type is Union) and type(None) in get_args(type_)
+
+    return origin_type is Union and type(None) in get_args(type_)

--- a/tests/test_python_typing_functions.py
+++ b/tests/test_python_typing_functions.py
@@ -6,21 +6,22 @@ from adapta.utils.python_typing import is_optional
 
 
 @pytest.mark.parametrize(
-    "test_type,expected",
+    "type_,expected",
     [
-        (is_optional(Optional[Union[str, int]]), True),
-        (is_optional(Optional[str]), True),
-        (is_optional(Union[str, None]), True),  # Same as Optional[str]
-        (is_optional(Union[str, Optional[int]]), True),  # Same as Union[str, int, None], which is an optional type
-        (is_optional(str), False),
-        (is_optional(Union[str, int]), False),
-        (is_optional(List[str]), False),
-        (is_optional(Tuple[int, ...]), False),
+        (Optional[Union[str, int]], True),
+        (Optional[str], True),
+        (Union[str, None], True),  # Same as Optional[str]
+        (Union[str, Optional[int]], True),  # Same as Union[str, int, None], which is an optional type
+        (str, False),
+        (Union[str, int], False),
+        (List[str], False),
+        (Tuple[int, ...], False),
+        (str | None, True),  # Semantically equivalent to Optional[str], but not the same union type
     ],
 )
-def test_is_optional(test_type: Any, expected: bool):
+def test_is_optional(type_: Any, expected: bool):
     """
     Test that the is_optional function correctly identifies optional types.
     """
 
-    assert test_type == expected
+    assert is_optional(type_) == expected

--- a/tests/test_python_typing_functions.py
+++ b/tests/test_python_typing_functions.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Optional, Union, List, Tuple, Any
 
 import pytest
@@ -16,7 +17,6 @@ from adapta.utils.python_typing import is_optional
         (Union[str, int], False),
         (List[str], False),
         (Tuple[int, ...], False),
-        (str | None, True),  # Semantically equivalent to Optional[str], but not the same union type
     ],
 )
 def test_is_optional(type_: Any, expected: bool):
@@ -25,3 +25,14 @@ def test_is_optional(type_: Any, expected: bool):
     """
 
     assert is_optional(type_) == expected
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Only run this test on Python 3.10+")
+def test_is_optional_python310():
+    """
+    Test that the is_optional function correctly identifies optional types on Python 3.10+.
+
+    str | None is semantically equivalent to Optional[str], but not the same union type
+    """
+
+    assert is_optional(str | None)

--- a/tests/test_python_typing_functions.py
+++ b/tests/test_python_typing_functions.py
@@ -36,3 +36,4 @@ def test_is_optional_python310():
     """
 
     assert is_optional(str | None)
+    assert not is_optional(str | int)


### PR DESCRIPTION
This pull request primarily focuses on making the `is_optional` function in `adapta/utils/python_typing/_functions.py` compatible with Python 3.10's new syntax for Union types. The changes also include updates to the corresponding tests in `tests/test_python_typing_functions.py` to ensure the function works as expected with the new syntax.

Here are the key changes:

Compatibility with Python 3.10's Union types:

* [`adapta/utils/python_typing/_functions.py`](diffhunk://#diff-1e713cf58e469146eaed72654a17b58b2f7ce03e772137fbf01258808243579aL2-R24): Added a conditional import and definition of `TypeHint` to handle Python 3.10's new `UnionType`. The `is_optional` function was updated to use `TypeHint` and to check for `UnionType` when running on Python 3.10 or later.

Test updates:

* [`tests/test_python_typing_functions.py`](diffhunk://#diff-675a2cff28db54512084da7fdff4dd61a7c815d721408711bca4b10d9b5b9d83R1): The `test_is_optional` function was updated to correctly call `is_optional` with the test types. A new test, `test_is_optional_python310`, was added to specifically test the function with Python 3.10's new Union type syntax. This test is skipped when running on Python versions earlier than 3.10. [[1]](diffhunk://#diff-675a2cff28db54512084da7fdff4dd61a7c815d721408711bca4b10d9b5b9d83R1) [[2]](diffhunk://#diff-675a2cff28db54512084da7fdff4dd61a7c815d721408711bca4b10d9b5b9d83L9-R39)