### PR TITLE
adding support for delta time travel based on a timestamp in adapta load function

### DIFF
--- a/adapta/storage/delta_lake/v2/_functions.py
+++ b/adapta/storage/delta_lake/v2/_functions.py
@@ -42,7 +42,7 @@ def load(  # pylint: disable=R0913
     auth_client: AuthenticationClient,
     path: DataPath,
     version: Optional[int] = None,
-    timestamp: Optional[Union[str, datetime.datetime]] = None,
+    timestamp: Optional[datetime.datetime] = None,
     row_filter: Optional[Union[Expression, pyarrow.compute.Expression]] = None,
     columns: Optional[List[str]] = None,
     batch_size: Optional[int] = None,
@@ -54,7 +54,7 @@ def load(  # pylint: disable=R0913
     :param auth_client: AuthenticationClient for target storage.
     :param path: Path to delta table, in HDFS format: abfss://container@account.dfs.core.windows.net/my/path
     :param version: Optional version to read. Defaults to latest. If set, timestamp will be ignored.
-    :param timestamp: Optional timestamp to read. If string, must be in format: "2021-01-01 00:00:00" ("%Y-%m-%d %H:%M:%S").
+    :param timestamp: Optional timestamp to read.
     :param row_filter: Optional filter to apply, as pyarrow expression. Example:
       from pyarrow.dataset import field as pyarrow_field
 
@@ -82,8 +82,6 @@ def load(  # pylint: disable=R0913
     pyarrow_ds = DeltaTable(path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path))
 
     if timestamp:
-        if not isinstance(timestamp, str):
-            timestamp = datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
         pyarrow_ds.load_as_version(timestamp)
 
     pyarrow_ds = pyarrow_ds.to_pyarrow_dataset(

--- a/adapta/storage/delta_lake/v2/_functions.py
+++ b/adapta/storage/delta_lake/v2/_functions.py
@@ -54,7 +54,7 @@ def load(  # pylint: disable=R0913
     :param auth_client: AuthenticationClient for target storage.
     :param path: Path to delta table, in HDFS format: abfss://container@account.dfs.core.windows.net/my/path
     :param version: Optional version to read. Defaults to latest. If set, timestamp will be ignored.
-    :param timestamp: Optional timestamp to read.
+    :param timestamp: Optional time travel timestamp. Allows to read data as of a specific time. Ignored if version is set.
     :param row_filter: Optional filter to apply, as pyarrow expression. Example:
       from pyarrow.dataset import field as pyarrow_field
 

--- a/adapta/storage/delta_lake/v2/_functions.py
+++ b/adapta/storage/delta_lake/v2/_functions.py
@@ -42,7 +42,7 @@ def load(  # pylint: disable=R0913
     auth_client: AuthenticationClient,
     path: DataPath,
     version: Optional[int] = None,
-    timestamp: Optional[Union[str, datetime]] = None,
+    timestamp: Optional[Union[str, datetime.datetime]] = None,
     row_filter: Optional[Union[Expression, pyarrow.compute.Expression]] = None,
     columns: Optional[List[str]] = None,
     batch_size: Optional[int] = None,

--- a/adapta/storage/delta_lake/v2/_functions.py
+++ b/adapta/storage/delta_lake/v2/_functions.py
@@ -42,6 +42,7 @@ def load(  # pylint: disable=R0913
     auth_client: AuthenticationClient,
     path: DataPath,
     version: Optional[int] = None,
+    timestamp: Optional[Union[str, datetime]] = None,
     row_filter: Optional[Union[Expression, pyarrow.compute.Expression]] = None,
     columns: Optional[List[str]] = None,
     batch_size: Optional[int] = None,
@@ -52,7 +53,8 @@ def load(  # pylint: disable=R0913
 
     :param auth_client: AuthenticationClient for target storage.
     :param path: Path to delta table, in HDFS format: abfss://container@account.dfs.core.windows.net/my/path
-    :param version: Optional version to read. Defaults to latest.
+    :param version: Optional version to read. Defaults to latest. If set, timestamp will be ignored.
+    :param timestamp: Optional timestamp to read. If string, must be in format: "2021-01-01 00:00:00" ("%Y-%m-%d %H:%M:%S").
     :param row_filter: Optional filter to apply, as pyarrow expression. Example:
       from pyarrow.dataset import field as pyarrow_field
 
@@ -74,10 +76,17 @@ def load(  # pylint: disable=R0913
         "Please upgrade to version 3: adapta.storage.delta_lake.v3",
         DeprecationWarning,
     )
+    if version:
+        timestamp = None
 
-    pyarrow_ds = DeltaTable(
-        path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path)
-    ).to_pyarrow_dataset(
+    pyarrow_ds = DeltaTable(path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path))
+
+    if timestamp:
+        if not isinstance(timestamp, str):
+            timestamp = datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+        pyarrow_ds.load_as_version(timestamp)
+
+    pyarrow_ds = pyarrow_ds.to_pyarrow_dataset(
         partitions=partition_filter_expressions,
         parquet_read_options=ParquetReadOptions(coerce_int96_timestamp_unit="ms"),
         filesystem=auth_client.get_pyarrow_filesystem(path),

--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -40,7 +40,7 @@ def load(  # pylint: disable=R0913
     auth_client: AuthenticationClient,
     path: DataPath,
     version: Optional[int] = None,
-    timestamp: Optional[Union[str, datetime.datetime]] = None,
+    timestamp: Optional[datetime.datetime] = None,
     row_filter: Optional[Union[Expression, pyarrow.compute.Expression]] = None,
     columns: Optional[List[str]] = None,
     batch_size: Optional[int] = None,
@@ -52,7 +52,7 @@ def load(  # pylint: disable=R0913
     :param auth_client: AuthenticationClient for target storage.
     :param path: Path to delta table, in HDFS format: abfss://container@account.dfs.core.windows.net/my/path
     :param version: Optional version to read. Defaults to latest. If set, timestamp is ignored.
-    :param timestamp: Optional timestamp to read. If string, must be in format: "2021-01-01 00:00:00" ("%Y-%m-%d %H:%M:%S").
+    :param timestamp: Optional timestamp to read.
     :param row_filter: Optional filter to apply, as pyarrow expression. Example:
       from pyarrow.dataset import field as pyarrow_field
 
@@ -74,8 +74,6 @@ def load(  # pylint: disable=R0913
     pyarrow_ds = DeltaTable(path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path))
 
     if timestamp:
-        if isinstance(timestamp, str):
-            timestamp = datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
         pyarrow_ds.load_as_version(timestamp)
 
     pyarrow_ds = pyarrow_ds.to_pyarrow_dataset(

--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -40,7 +40,7 @@ def load(  # pylint: disable=R0913
     auth_client: AuthenticationClient,
     path: DataPath,
     version: Optional[int] = None,
-    timestamp: Optional[Union[str, datetime]] = None,
+    timestamp: Optional[Union[str, datetime.datetime]] = None,
     row_filter: Optional[Union[Expression, pyarrow.compute.Expression]] = None,
     columns: Optional[List[str]] = None,
     batch_size: Optional[int] = None,

--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -40,6 +40,7 @@ def load(  # pylint: disable=R0913
     auth_client: AuthenticationClient,
     path: DataPath,
     version: Optional[int] = None,
+    timestamp: Optional[Union[str, datetime]] = None,
     row_filter: Optional[Union[Expression, pyarrow.compute.Expression]] = None,
     columns: Optional[List[str]] = None,
     batch_size: Optional[int] = None,
@@ -50,7 +51,8 @@ def load(  # pylint: disable=R0913
 
     :param auth_client: AuthenticationClient for target storage.
     :param path: Path to delta table, in HDFS format: abfss://container@account.dfs.core.windows.net/my/path
-    :param version: Optional version to read. Defaults to latest.
+    :param version: Optional version to read. Defaults to latest. If set, timestamp is ignored.
+    :param timestamp: Optional timestamp to read. If string, must be in format: "2021-01-01 00:00:00" ("%Y-%m-%d %H:%M:%S").
     :param row_filter: Optional filter to apply, as pyarrow expression. Example:
       from pyarrow.dataset import field as pyarrow_field
 
@@ -66,9 +68,17 @@ def load(  # pylint: disable=R0913
 
     :return: A DeltaTable wrapped Rust class, pandas Dataframe or an iterator of pandas Dataframes, for batched reads.
     """
-    pyarrow_ds = DeltaTable(
-        path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path)
-    ).to_pyarrow_dataset(
+    if version:
+        timestamp = None
+
+    pyarrow_ds = DeltaTable(path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path))
+
+    if timestamp:
+        if isinstance(timestamp, str):
+            timestamp = datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+        pyarrow_ds.load_as_version(timestamp)
+
+    pyarrow_ds = pyarrow_ds.to_pyarrow_dataset(
         partitions=partition_filter_expressions,
         parquet_read_options=ParquetReadOptions(coerce_int96_timestamp_unit="ms"),
         filesystem=auth_client.get_pyarrow_filesystem(path),

--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -52,7 +52,7 @@ def load(  # pylint: disable=R0913
     :param auth_client: AuthenticationClient for target storage.
     :param path: Path to delta table, in HDFS format: abfss://container@account.dfs.core.windows.net/my/path
     :param version: Optional version to read. Defaults to latest. If set, timestamp is ignored.
-    :param timestamp: Optional timestamp to read.
+    :param timestamp: Optional time travel timestamp. Allows to read data as of a specific time. Ignored if version is set.
     :param row_filter: Optional filter to apply, as pyarrow expression. Example:
       from pyarrow.dataset import field as pyarrow_field
 

--- a/tests/test_delta_history.py
+++ b/tests/test_delta_history.py
@@ -66,7 +66,7 @@ def test_delta_history_full(get_client_and_path):
     ]
 
 
-@pytest.mark.parametrize("timestamp", [datetime(year=1900, month=1, day=1), "1900-01-01 00:00:00"])
+@pytest.mark.parametrize("timestamp", [datetime(year=1900, month=1, day=1)])
 def test_delta_time_travel(get_client_and_path, timestamp):
     client, data_path = get_client_and_path
     current_table: pandas.DataFrame = load(client, data_path).to_pandas()


### PR DESCRIPTION
Implemented:
Added a new parameter _timestamp_ to the adapta.storage.delta_lake.v3.load function (alias adapta.storage.delta_lake.load). This enhancement enables users to load a version of a delta table based on a specified timestamp. The function retrieves the version with the closest creation timestamp to the provided argument. Timestamps can be supplied as a datetime object.

Example:
data = load(auth_client, data_path, timpestamp=datetime.datetime(year=2024, month=7, day=25))