### PR TITLE
Fixes imports

### DIFF
--- a/adapta/storage/database/__init__.py
+++ b/adapta/storage/database/__init__.py
@@ -15,5 +15,3 @@ Import index
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
-from adapta.storage.database.v2 import *


### PR DESCRIPTION
This does not work as intended. You need all db extras to import something from the database module.
I propose we remove the automatic import of all v2 database libs