### PR TITLE
Remove kwargs arg on AwsClient constructor

### DIFF
--- a/adapta/security/clients/aws/_aws_client.py
+++ b/adapta/security/clients/aws/_aws_client.py
@@ -33,8 +33,8 @@ class AwsClient(AuthenticationClient):
     AWS Credentials provider for various AWS resources.
     """
 
-    def __init__(self, credentials: Optional[AccessKeyCredentials] = None, allow_http: bool = False, **_):
-        super().__init__(**_)
+    def __init__(self, credentials: Optional[AccessKeyCredentials] = None, allow_http: bool = False):
+        super().__init__()
         self._session = None
         self._credentials = credentials
         self._allow_http = allow_http


### PR DESCRIPTION
Removes **_ kwarg argument on AwsClient Constructor to ensure linter catches breaking change from `aws_credentials=...` to `credentials=...`