### PR TITLE
Fix missing to_dict method

### DIFF
--- a/adapta/storage/models/hive.py
+++ b/adapta/storage/models/hive.py
@@ -1,6 +1,7 @@
 """
  Models used by Hive storages.
 """
+
 #  Copyright (c) 2023-2024. ECCO Sneaks & Data
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -130,26 +131,34 @@ class HivePath(DataPath):
                 password=os.environ["PROTEUS__HIVE_PASSWORD"],
                 database_type=self.database_type,
             ) as hive_db_client:
-                db_info = hive_db_client.query(f"select * from DBS where name = '{self.hive_schema}'").to_dict(
-                    orient="records"
+                db_info = (
+                    hive_db_client.query(f"select * from DBS where name = '{self.hive_schema}'")
+                    .to_pandas()
+                    .to_dict(orient="records")
                 )
                 assert (
                     len(db_info) == 1
                 ), "Hive query for DBS table returned more than 1 row. Hive Metastore database schema version must be >=2.*,<=3.*"
                 db_id, db_location = db_info[0]["DB_ID"], db_info[0]["DB_LOCATION_URI"]
 
-                tbl_info = hive_db_client.query(
-                    f"select * from TBLS where db_id = {db_id} and TBL_NAME = '{self.hive_table}'"
-                ).to_dict(orient="records")
+                tbl_info = (
+                    hive_db_client.query(f"select * from TBLS where db_id = {db_id} and TBL_NAME = '{self.hive_table}'")
+                    .to_pandas()
+                    .to_dict(orient="records")
+                )
                 assert (
                     len(tbl_info) == 1
                 ), "Hive query for TBLS table returned more than 1 row. Hive Metastore database schema version must be >=2.*,<=3.*"
                 sd_id, tbl_type = tbl_info[0]["SD_ID"], tbl_info[0]["TBL_TYPE"]
 
                 if tbl_type == "EXTERNAL_TABLE":
-                    path = hive_db_client.query(
-                        f"select * from SERDE_PARAMS where SERDE_ID = {sd_id} and PARAM_KEY = 'path'"
-                    ).to_dict(orient="records")
+                    path = (
+                        hive_db_client.query(
+                            f"select * from SERDE_PARAMS where SERDE_ID = {sd_id} and PARAM_KEY = 'path'"
+                        )
+                        .to_pandas()
+                        .to_dict(orient="records")
+                    )
                     assert (
                         len(path) == 1
                     ), "Hive query for SERDE_PARAMS table returned more than 1 row. Hive Metastore database schema version must be >=2.*,<=3.*"


### PR DESCRIPTION
After switching to `MetaFrame`s, the `query` result no longer has a `to_dict` method.
So add a cast to pandas first

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
