### PR TITLE
Introduce limit parameter in QES read method

### DIFF
--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -45,6 +45,7 @@ def load(  # pylint: disable=R0913
     columns: Optional[List[str]] = None,
     batch_size: Optional[int] = None,
     partition_filter_expressions: Optional[List[Tuple]] = None,
+    limit: Optional[int] = None,
 ) -> Union[MetaFrame, Iterator[MetaFrame]]:
     """
      Loads Delta Lake table from Azure or AWS storage and converts it to a pandas dataframe.
@@ -60,6 +61,7 @@ def load(  # pylint: disable=R0913
 
     :param columns: Optional list of columns to select when reading. Defaults to all columns of not provided.
     :param batch_size: Optional batch size when reading in batches. If not set, whole table will be loaded into memory.
+    :param limit: Optional limit on number of rows to read.
     :param partition_filter_expressions: Optional partitions filters. Examples:
 
        partition_filter_expressions = [("day", "=", "3")]
@@ -80,7 +82,7 @@ def load(  # pylint: disable=R0913
         partitions=partition_filter_expressions,
         parquet_read_options=ParquetReadOptions(coerce_int96_timestamp_unit="ms"),
         filesystem=auth_client.get_pyarrow_filesystem(path),
-    )
+    ).head(limit)
 
     row_filter = (
         compile_expression(row_filter, ArrowFilterExpression) if isinstance(row_filter, Expression) else row_filter

--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -82,7 +82,10 @@ def load(  # pylint: disable=R0913
         partitions=partition_filter_expressions,
         parquet_read_options=ParquetReadOptions(coerce_int96_timestamp_unit="ms"),
         filesystem=auth_client.get_pyarrow_filesystem(path),
-    ).head(limit)
+    )
+
+    if limit:
+        pyarrow_ds = pyarrow_ds.head(limit)
 
     row_filter = (
         compile_expression(row_filter, ArrowFilterExpression) if isinstance(row_filter, Expression) else row_filter

--- a/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
@@ -238,6 +238,7 @@ class AstraClient:
         custom_indexes: Optional[List[str]] = None,
         deduplicate=False,
         num_threads: Optional[int] = None,
+        limit: Optional[int] = None,
     ) -> MetaFrame:
         """
         Run a filter query on the entity of type TModel backed by table `table_name`.
@@ -262,6 +263,7 @@ class AstraClient:
         :param: custom_indexes: An optional list of custom indexes, if it cannot be inferred, if it cannot be inferred from the data model.
         :param: deduplicate: Optionally deduplicate query result, for example when only the partition key part of a primary key is used to fetch results.
         :param: num_threads: Optionally run filtering using multiple threads. Setting this to -1 will cause this method to automatically evaluate number of threads based on filter expression size.
+        :param: limit: Optionally limit the number of results returned.
         """
 
         @on_exception(
@@ -275,10 +277,11 @@ class AstraClient:
             raise_on_giveup=True,
         )
         def apply(model: Type[Model], key_column_filter: Dict[str, Any], columns_to_select: Optional[List[str]]):
+            model = model.filter(**key_column_filter).limit(limit)
             if columns_to_select:
-                return model.filter(**key_column_filter).only(select_columns)
+                return model.only(select_columns)
 
-            return model.filter(**key_column_filter)
+            return model
 
         def normalize_column_name(column_name: str) -> str:
             filter_suffix = re.findall(self._filter_pattern, column_name)

--- a/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
@@ -18,6 +18,7 @@
 #
 
 import base64
+import itertools
 import logging
 import math
 import os
@@ -276,12 +277,14 @@ class AstraClient:
             max_time=self._transient_error_max_wait_s,
             raise_on_giveup=True,
         )
-        def apply(model: Type[Model], key_column_filter: Dict[str, Any], columns_to_select: Optional[List[str]]):
+        def apply(
+            model: Type[Model], key_column_filter: Dict[str, Any], columns_to_select: Optional[List[str]]
+        ) -> typing.Iterable[dict]:
             model = model.filter(**key_column_filter).limit(limit)
             if columns_to_select:
-                return model.only(select_columns)
+                model = model.only(select_columns)
 
-            return model
+            return (dict(v.items()) for v in list(model))
 
         def normalize_column_name(column_name: str) -> str:
             filter_suffix = re.findall(self._filter_pattern, column_name)
@@ -289,15 +292,6 @@ class AstraClient:
                 return column_name
 
             return column_name.replace(filter_suffix[0], "")
-
-        def to_frame(
-            model: Type[Model], key_column_filter: Dict[str, Any], columns_to_select: Optional[List[str]]
-        ) -> MetaFrame:
-            return MetaFrame(
-                [dict(v.items()) for v in list(apply(model, key_column_filter, columns_to_select))],
-                convert_to_polars=lambda x: polars.DataFrame(x, schema=select_columns),
-                convert_to_pandas=lambda x: pandas.DataFrame(x, columns=select_columns),
-            )
 
         assert (
             self._session is not None
@@ -327,33 +321,33 @@ class AstraClient:
                 else num_threads
             )
             with ThreadPoolExecutor(max_workers=max_threads) as tpe:
-                result = concat(
-                    tpe.map(
-                        lambda args: to_frame(*args),
-                        [
-                            (cassandra_model, key_column_filter, select_columns)
-                            for key_column_filter in compiled_filter_values
-                        ],
-                        chunksize=max(int(len(compiled_filter_values) / num_threads), 1),
-                    )
+                data = tpe.map(
+                    lambda args: apply(*args),
+                    [
+                        (cassandra_model, key_column_filter, select_columns)
+                        for key_column_filter in compiled_filter_values
+                    ],
+                    chunksize=max(int(len(compiled_filter_values) / num_threads), 1),
                 )
         else:
-            result = concat(
-                [
-                    MetaFrame(
-                        [dict(v.items()) for v in list(apply(cassandra_model, key_column_filter, select_columns))],
-                        convert_to_polars=(lambda x: polars.DataFrame(x, schema=select_columns))
-                        if not deduplicate
-                        else (lambda x: polars.DataFrame(x, schema=select_columns).unique()),
-                        convert_to_pandas=(lambda x: pandas.DataFrame(x, columns=select_columns))
-                        if not deduplicate
-                        else (lambda x: pandas.DataFrame(x, columns=select_columns).drop_duplicates()),
-                    )
-                    for key_column_filter in compiled_filter_values
-                ]
+            data = (
+                apply(cassandra_model, key_column_filter, select_columns)
+                for key_column_filter in compiled_filter_values
             )
 
-        return result
+        data = itertools.chain.from_iterable(data)
+        if limit:
+            data = itertools.islice(data, limit)
+
+        return MetaFrame(
+            data,
+            convert_to_polars=(lambda x: polars.DataFrame(x, schema=select_columns))
+            if not deduplicate
+            else (lambda x: polars.DataFrame(x, schema=select_columns).unique()),
+            convert_to_pandas=(lambda x: pandas.DataFrame(x, columns=select_columns))
+            if not deduplicate
+            else (lambda x: pandas.DataFrame(x, columns=select_columns).drop_duplicates()),
+        )
 
     def get_entities_raw(self, query: str) -> MetaFrame:
         """

--- a/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
@@ -63,7 +63,7 @@ from adapta import __version__
 from adapta.storage.distributed_object_store.v3.datastax_astra._models import SimilarityFunction, VectorSearchQuery
 from adapta.storage.models.filter_expression import Expression, AstraFilterExpression, compile_expression
 from adapta.utils import chunk_list, rate_limit
-from adapta.utils.metaframe import MetaFrame, concat
+from adapta.utils.metaframe import MetaFrame
 from adapta.storage.distributed_object_store.v3.datastax_astra._model_mappers import get_mapper
 
 TModel = TypeVar("TModel")  # pylint: disable=C0103

--- a/adapta/storage/query_enabled_store/_models.py
+++ b/adapta/storage/query_enabled_store/_models.py
@@ -83,16 +83,16 @@ class QueryEnabledStore(Generic[TCredential, TSettings], ABC):
 
     @abstractmethod
     def _apply_filter(
-        self, path: DataPath, filter_expression: Expression, columns: list[str]
+        self, path: DataPath, filter_expression: Expression, columns: list[str], limit: Optional[int] = 10000
     ) -> Union[MetaFrame, Iterator[MetaFrame]]:
         """
-        Applies the provided filter expression to this Store and returns the result in a pandas DataFrame
+        Applies the provided filter expression to this Store and returns the result in a MetaFrame
         """
 
     @abstractmethod
     def _apply_query(self, query: str) -> Union[MetaFrame, Iterator[MetaFrame]]:
         """
-        Applies a plaintext query to this Store and returns the result in a pandas DataFrame
+        Applies a plaintext query to this Store and returns the result in a MetaFrame
         """
 
     @classmethod
@@ -156,10 +156,13 @@ class QueryConfigurationBuilder:
         self._columns = list(columns)
         return self
 
-    def read(self) -> Union[MetaFrame, Iterator[MetaFrame]]:
+    def read(self, limit: Optional[int] = 10000) -> Union[MetaFrame, Iterator[MetaFrame]]:
         """
         Execute the query on the underlying store.
         """
         return self._store._apply_filter(
-            path=self._path, filter_expression=self._filter_expression, columns=self._columns
+            path=self._path,
+            filter_expression=self._filter_expression,
+            columns=self._columns,
+            limit=limit,
         )

--- a/adapta/storage/query_enabled_store/_models.py
+++ b/adapta/storage/query_enabled_store/_models.py
@@ -139,6 +139,7 @@ class QueryConfigurationBuilder:
         self._path = path
         self._filter_expression: Optional[Expression] = None
         self._columns: list[str] = []
+        self._limit = 10000
 
     def filter(self, filter_expression: Expression) -> "QueryConfigurationBuilder":
         """
@@ -156,7 +157,14 @@ class QueryConfigurationBuilder:
         self._columns = list(columns)
         return self
 
-    def read(self, limit: Optional[int] = 10000) -> Union[MetaFrame, Iterator[MetaFrame]]:
+    def limit(self, limit: int) -> "QueryConfigurationBuilder":
+        """
+        Limit the number of results returned by the underlying store.
+        """
+        self._limit = limit
+        return self
+
+    def read(self) -> Union[MetaFrame, Iterator[MetaFrame]]:
         """
         Execute the query on the underlying store.
         """
@@ -164,5 +172,5 @@ class QueryConfigurationBuilder:
             path=self._path,
             filter_expression=self._filter_expression,
             columns=self._columns,
-            limit=limit,
+            limit=self._limit,
         )

--- a/adapta/storage/query_enabled_store/_qes_astra.py
+++ b/adapta/storage/query_enabled_store/_qes_astra.py
@@ -78,7 +78,7 @@ class AstraQueryEnabledStore(QueryEnabledStore[AstraCredential, AstraSettings]):
             self._astra_client.connect()
 
     def _apply_filter(
-        self, path: DataPath, filter_expression: Expression, columns: list[str]
+        self, path: DataPath, filter_expression: Expression, columns: list[str], limit: Optional[int] = 10000
     ) -> Union[MetaFrame, Iterator[MetaFrame]]:
         assert isinstance(path, AstraPath)
         astra_path: AstraPath = path
@@ -91,6 +91,7 @@ class AstraQueryEnabledStore(QueryEnabledStore[AstraCredential, AstraSettings]):
                     table_name=astra_path.table,
                     select_columns=columns,
                     num_threads=-1,  # auto-infer, see method documentation
+                    limit=limit,
                 )
 
         return self._astra_client.filter_entities(
@@ -100,6 +101,7 @@ class AstraQueryEnabledStore(QueryEnabledStore[AstraCredential, AstraSettings]):
             table_name=astra_path.table,
             select_columns=columns,
             num_threads=-1,  # auto-infer, see method documentation
+            limit=limit,
         )
 
     def _apply_query(self, query: str) -> Union[MetaFrame, Iterator[MetaFrame]]:

--- a/adapta/storage/query_enabled_store/_qes_delta.py
+++ b/adapta/storage/query_enabled_store/_qes_delta.py
@@ -67,13 +67,18 @@ class DeltaQueryEnabledStore(QueryEnabledStore[DeltaCredential, DeltaSettings]):
         return cls(credentials=DeltaCredential.from_json(credentials), settings=DeltaSettings.from_json(settings))
 
     def _apply_filter(
-        self, path: DataPath, filter_expression: Expression, columns: list[str]
+        self,
+        path: DataPath,
+        filter_expression: Expression,
+        columns: list[str],
+        limit: Optional[int] = 10000,
     ) -> Union[MetaFrame, Iterator[MetaFrame]]:
         return load(
             auth_client=self.credentials.auth_client(credentials=self.credentials.auth_client_credentials()),
             path=path,
             row_filter=filter_expression,
             columns=columns,
+            limit=limit,
         )
 
     def _apply_query(self, query: str) -> Union[MetaFrame, Iterator[MetaFrame]]:


### PR DESCRIPTION
This PR introduces the ability to limit the results returned by the QES.

As part of this enhancement, the AstraClient has been refactored. The most notable change is the replacement of the `concat` method for MetaFrames with a call to `itertools.chain.from_iterable`