### PR TITLE
Fix to query store columns when fetching empty result

### DIFF
--- a/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
@@ -30,7 +30,6 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from typing import Optional, Dict, TypeVar, Callable, Type, List, Any, Union
 
-from adapta.schema_management.schema_entity import PythonSchemaEntity
 try:
     from _socket import IPPROTO_TCP, TCP_NODELAY, TCP_USER_TIMEOUT
 except ImportError:
@@ -65,6 +64,7 @@ from adapta.storage.models.filter_expression import Expression, AstraFilterExpre
 from adapta.utils import chunk_list, rate_limit
 from adapta.utils.metaframe import MetaFrame, concat
 from adapta.storage.distributed_object_store.v3.datastax_astra._model_mappers import get_mapper
+from adapta.schema_management.schema_entity import PythonSchemaEntity
 
 TModel = TypeVar("TModel")  # pylint: disable=C0103
 

--- a/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
@@ -30,6 +30,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from typing import Optional, Dict, TypeVar, Callable, Type, List, Any, Union
 
+from adapta.schema_management.schema_entity import PythonSchemaEntity
 try:
     from _socket import IPPROTO_TCP, TCP_NODELAY, TCP_USER_TIMEOUT
 except ImportError:
@@ -293,7 +294,9 @@ class AstraClient:
             return MetaFrame(
                 [dict(v.items()) for v in list(apply(model, key_column_filter, columns_to_select))],
                 convert_to_polars=lambda x: polars.DataFrame(x, schema=select_columns),
-                convert_to_pandas=lambda x: pandas.DataFrame(x, columns=select_columns),
+                convert_to_pandas=lambda x: pandas.DataFrame(
+                    x, columns=select_columns or PythonSchemaEntity(model).get_field_names()
+                ),
             )
 
         assert (


### PR DESCRIPTION
I have this issue when running this:

self._store.open(self.socket.parse_data_path()).filter(filters).read().to_pandas()

And getting an empty result. In this cases I am getting a pandas dataframe with no columns, but I would like for it to give me an empty dataframe with the column of the data model from the socket.

This is a temporary fix and should be handled better in the future, see https://github.com/SneaksAndData/adapta/issues/504