### PR TITLE
Fix to query store columns when fetching empty result again

### DIFF
--- a/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
+++ b/adapta/storage/distributed_object_store/v3/datastax_astra/astra_client.py
@@ -294,16 +294,18 @@ class AstraClient:
             return MetaFrame(
                 [dict(v.items()) for v in list(apply(model, key_column_filter, columns_to_select))],
                 convert_to_polars=lambda x: polars.DataFrame(x, schema=select_columns),
-                convert_to_pandas=lambda x: pandas.DataFrame(
-                    x, columns=select_columns or PythonSchemaEntity(model).get_field_names()
-                ),
+                convert_to_pandas=lambda x: pandas.DataFrame(x, columns=select_columns),
             )
 
         assert (
             self._session is not None
         ), "Please instantiate an AstraClient using with AstraClient(...) before calling this method"
 
-        select_columns = list(map(normalize_column_name, select_columns)) if select_columns else None
+        select_columns = (
+            list(map(normalize_column_name, select_columns))
+            if select_columns
+            else PythonSchemaEntity(model_class).get_field_names()
+        )
 
         cassandra_model = get_mapper(
             data_model=model_class,


### PR DESCRIPTION
I have this issue when running this:

self._store.open(self.socket.parse_data_path()).filter(filters).read().to_pandas()

And getting an empty result. In this cases I am getting a pandas dataframe with no columns, but I would like for it to give me an empty dataframe with the column of the data model from the socket.

This is fixes the bug from #503 bug might need a better fix in the future - see #504 