### PR TITLE
Allow to fetching all columns in delta reader

### DIFF
--- a/adapta/storage/query_enabled_store/_qes_delta.py
+++ b/adapta/storage/query_enabled_store/_qes_delta.py
@@ -73,7 +73,7 @@ class DeltaQueryEnabledStore(QueryEnabledStore[DeltaCredential, DeltaSettings]):
             auth_client=self.credentials.auth_client(credentials=self.credentials.auth_client_credentials()),
             path=path,
             row_filter=filter_expression,
-            columns=columns,
+            columns=columns if columns else None,
         )
 
     def _apply_query(self, query: str) -> Union[MetaFrame, Iterator[MetaFrame]]:


### PR DESCRIPTION
Align QES delta implementation with Astra and Local implementations, interpreting empty list of columns as all columns