### PR TITLE
Add timout option to delta reader

### DIFF
--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -46,6 +46,7 @@ def load(  # pylint: disable=R0913
     batch_size: Optional[int] = None,
     partition_filter_expressions: Optional[List[Tuple]] = None,
     limit: Optional[int] = None,
+    timeout: Optional[int] = None,
 ) -> Union[MetaFrame, Iterator[MetaFrame]]:
     """
      Loads Delta Lake table from Azure or AWS storage and converts it to a pandas dataframe.
@@ -68,10 +69,16 @@ def load(  # pylint: disable=R0913
        partition_filter_expressions = [("day", "in", ["3", "20"])]
        partition_filter_expressions = [("day", "not in", ["3", "20"]), ("year", "=", "2021")]
 
+    :param timeout: Optional timeout for the read operation. Measured in seconds.
     :return: A DeltaTable wrapped Rust class, pandas Dataframe or an iterator of pandas Dataframes, for batched reads.
     """
     if version:
         timestamp = None
+
+    storage_options = auth_client.connect_storage(path)
+
+    if timeout is not None:
+        storage_options["timeout"] = f"{timeout}s"
 
     pyarrow_ds = DeltaTable(path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path))
 

--- a/adapta/storage/delta_lake/v3/_functions.py
+++ b/adapta/storage/delta_lake/v3/_functions.py
@@ -80,7 +80,7 @@ def load(  # pylint: disable=R0913
     if timeout is not None:
         storage_options["timeout"] = f"{timeout}s"
 
-    pyarrow_ds = DeltaTable(path.to_delta_rs_path(), version=version, storage_options=auth_client.connect_storage(path))
+    pyarrow_ds = DeltaTable(path.to_delta_rs_path(), version=version, storage_options=storage_options)
 
     if timestamp:
         pyarrow_ds.load_as_version(timestamp)

--- a/adapta/storage/models/enum.py
+++ b/adapta/storage/models/enum.py
@@ -10,6 +10,8 @@ class QueryEnabledStoreOptions(Enum):
     QES options aliases in Adapta.
 
     If CONCAT_OPTIONS is used, list[MetaFrameOptions] is expected.
+    If TIMEOUT is used, int is expected (time measured in seconds).
     """
 
     CONCAT_OPTIONS = "concat_options"
+    TIMEOUT = "timeout"

--- a/adapta/storage/query_enabled_store/_qes_delta.py
+++ b/adapta/storage/query_enabled_store/_qes_delta.py
@@ -84,6 +84,7 @@ class DeltaQueryEnabledStore(QueryEnabledStore[DeltaCredential, DeltaSettings]):
             row_filter=filter_expression,
             columns=columns if columns else None,
             limit=limit,
+            timeout=options.get(QueryEnabledStoreOptions.TIMEOUT, None),
         )
 
     def _apply_query(self, query: str) -> Union[MetaFrame, Iterator[MetaFrame]]:


### PR DESCRIPTION
We sometimes face issues with Generic S3 errors which seem to be timeouts. Adding functionality to adjust timeout to hopefully reduce the frequency of those errors. I couldn't figure out what the default timeout is for delta.