### PR TITLE
Fix delta limit parameter in Delta QES

### DIFF
--- a/adapta/storage/query_enabled_store/_models.py
+++ b/adapta/storage/query_enabled_store/_models.py
@@ -147,7 +147,7 @@ class QueryConfigurationBuilder:
         self._filter_expression: Optional[Expression] = None
         self._columns: list[str] = []
         self._options: dict[QueryEnabledStoreOptions, any] = {}
-        self._limit = 10000
+        self._limit = None
 
     def filter(self, filter_expression: Expression) -> "QueryConfigurationBuilder":
         """


### PR DESCRIPTION
Last release included a limit parameter in QES, e.g. DeltaQES. This turned out to be breaking for 2 reasons:
1) Now there is a default limit parameter set to 10000 rows. If I need more (which I often do) I have to update all QES reads in my code
2) The use of head on a pyarrow dataset turns it to a table which makes the following code line failing:
```python
pyarrow_table: Table = pyarrow_ds.to_table(filter=row_filter, columns=columns)
```