### PR TITLE
Fix for serializers property name

### DIFF
--- a/adapta/storage/models/formatters/dict.py
+++ b/adapta/storage/models/formatters/dict.py
@@ -35,4 +35,4 @@ class DictJsonSerializationFormatWithFileFormat(DictJsonSerializationFormat):
     Serializes dictionaries as JSON format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True

--- a/adapta/storage/models/formatters/metaframe.py
+++ b/adapta/storage/models/formatters/metaframe.py
@@ -45,4 +45,4 @@ class MetaFrameParquetSerializationFormatWithFileFormat(MetaFrameParquetSerializ
     Serializes MetaFrames as parquet format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True

--- a/adapta/storage/models/formatters/pandas.py
+++ b/adapta/storage/models/formatters/pandas.py
@@ -38,7 +38,7 @@ class PandasDataFrameJsonSerializationFormatWithFileFormat(PandasDataFrameJsonSe
     Serializes dataframes as JSON format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PandasDataFrameCsvSerializationFormat(SerializationFormat[pandas.DataFrame]):
@@ -70,7 +70,7 @@ class PandasDataFrameCsvSerializationFormatWithFileFormat(PandasDataFrameCsvSeri
     Serializes dataframes as CSV format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PandasDataFrameParquetSerializationFormat(SerializationFormat[pandas.DataFrame]):
@@ -102,7 +102,7 @@ class PandasDataFrameParquetSerializationFormatWithFileFormat(PandasDataFramePar
     Serializes dataframes as parquet format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PandasDataFrameExcelSerializationFormat(SerializationFormat[pandas.DataFrame]):
@@ -136,4 +136,4 @@ class PandasDataFrameExcelSerializationFormatWithFileFormat(PandasDataFrameExcel
     Serializes dataframes as Excel (.xlsx) format with file format extension.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True

--- a/adapta/storage/models/formatters/pickle.py
+++ b/adapta/storage/models/formatters/pickle.py
@@ -33,4 +33,4 @@ class PickleSerializationFormatWithFileFormat(PickleSerializationFormat):
     Serializes objects as pickle format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True

--- a/adapta/storage/models/formatters/polars.py
+++ b/adapta/storage/models/formatters/polars.py
@@ -37,7 +37,7 @@ class PolarsLazyFrameJsonSerializationFormatWithFileFormat(PolarsLazyFrameJsonSe
     Serializes lazyframes as JSON format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PolarsLazyFrameCsvSerializationFormat(SerializationFormat[polars.LazyFrame]):
@@ -70,7 +70,7 @@ class PolarsLazyFrameCsvSerializationFormatWithFileFormat(PolarsLazyFrameCsvSeri
     Serializes lazyframes as CSV format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PolarsLazyFrameParquetSerializationFormat(SerializationFormat[polars.LazyFrame]):
@@ -104,7 +104,7 @@ class PolarsLazyFrameParquetSerializationFormatWithFileFormat(PolarsLazyFramePar
     Serializes lazyframes as parquet format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PolarsDataFrameJsonSerializationFormat(SerializationFormat[polars.DataFrame]):
@@ -136,7 +136,7 @@ class PolarsDataFrameJsonSerializationFormatWithFileFormat(PolarsDataFrameJsonSe
     Serializes dataframes as JSON format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PolarsDataFrameCsvSerializationFormat(SerializationFormat[polars.DataFrame]):
@@ -169,7 +169,7 @@ class PolarsDataFrameCsvSerializationFormatWithFileFormat(PolarsDataFrameCsvSeri
     Serializes dataframes as CSV format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PolarsDataFrameParquetSerializationFormat(SerializationFormat[polars.DataFrame]):
@@ -203,7 +203,7 @@ class PolarsDataFrameParquetSerializationFormatWithFileFormat(PolarsDataFramePar
     Serializes dataframes as parquet format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True
 
 
 class PolarsDataFrameExcelSerializationFormat(SerializationFormat[polars.DataFrame]):
@@ -237,4 +237,4 @@ class PolarsDataFrameExcelSerializationFormatWithFileFormat(PolarsDataFrameExcel
     Serializes dataframes as Excel (.xlsx) format with file format.
     """
 
-    include_file_format_in_output_name = True
+    append_file_format_extension = True


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
 - Base class for serializer has property "append_file_format_extension" while implementations had include_file_format_in_output_name

Additional changes:

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
