### PR TITLE
add model tags to register_mlflow_model function

### DIFF
--- a/adapta/ml/mlflow/_functions.py
+++ b/adapta/ml/mlflow/_functions.py
@@ -113,6 +113,7 @@ def register_mlflow_model(
             python_model=_MlflowMachineLearningModel(),
             registered_model_name=model_name,
             artifacts=artifacts,
+            tags=model_tags,
         )
 
         if metrics is not None:


### PR DESCRIPTION
Current MLFlow register_mlflow_model function is not able to log model_tags. Current model tags are logged in the experiment and not in the registered model. This addition will enable users to check tags in each registered model