### PR TITLE
Allow having empty lists in concat method

### DIFF
--- a/adapta/utils/metaframe.py
+++ b/adapta/utils/metaframe.py
@@ -123,7 +123,7 @@ def concat(dataframes: Iterable[MetaFrame], options: Iterable[MetaFrameOptions] 
     :return: Concatenated MetaFrame.
     """
 
-    if not dataframes:
+    if not [df for df in dataframes]:
         return MetaFrame(
             data=[],
             convert_to_polars=lambda _: polars.DataFrame(),

--- a/adapta/utils/metaframe.py
+++ b/adapta/utils/metaframe.py
@@ -5,7 +5,6 @@ The MetaFrame can be used to convert the latent representation to other formats.
 import itertools
 from abc import ABC
 from collections.abc import Callable, Iterable
-from typing import Self
 
 import pandas
 import polars
@@ -49,16 +48,6 @@ class MetaFrame:
         self._data = data
         self._convert_to_polars = convert_to_polars
         self._convert_to_pandas = convert_to_pandas
-
-    def clone(self) -> Self:
-        """
-        Clone the MetaFrame.
-        """
-        return MetaFrame(
-            data=self._data,
-            convert_to_polars=self._convert_to_polars,
-            convert_to_pandas=self._convert_to_pandas,
-        )
 
     @classmethod
     def from_pandas(
@@ -115,22 +104,26 @@ class MetaFrame:
             convert_to_pandas=convert_to_pandas or (lambda x: x.to_pandas()),
         )
 
+    def _check_if_materialized(self) -> None:
+        if self._materialized:
+            raise RuntimeError(
+                "MetaFrame has already been materialized. You can only call 'to_pandas' or 'to_polars' once."
+            )
+
+        self._materialized = True
+
     def to_pandas(self) -> pandas.DataFrame:
         """
         Convert the MetaFrame to a pandas DataFrame.
         """
-        if self._materialized:
-            raise RuntimeError("no")
-        self._materialized = True
+        self._check_if_materialized()
         return self._convert_to_pandas(self._data)
 
     def to_polars(self) -> polars.DataFrame:
         """
         Convert the MetaFrame to a Polars DataFrame.
         """
-        if self._materialized:
-            raise RuntimeError("no")
-        self._materialized = True
+        self._check_if_materialized()
         return self._convert_to_polars(self._data)
 
 

--- a/adapta/utils/metaframe.py
+++ b/adapta/utils/metaframe.py
@@ -122,6 +122,14 @@ def concat(dataframes: Iterable[MetaFrame], options: Iterable[MetaFrameOptions] 
     :param options: Options for the concatenation.
     :return: Concatenated MetaFrame.
     """
+
+    if not dataframes:
+        return MetaFrame(
+            data=[],
+            convert_to_polars=lambda _: polars.DataFrame(),
+            convert_to_pandas=lambda _: pandas.DataFrame(),
+        )
+
     if options is None:
         options = []
 

--- a/adapta/utils/metaframe.py
+++ b/adapta/utils/metaframe.py
@@ -123,7 +123,9 @@ def concat(dataframes: Iterable[MetaFrame], options: Iterable[MetaFrameOptions] 
     :return: Concatenated MetaFrame.
     """
 
-    if not list(dataframes):
+    dataframe_list = list(dataframes)
+
+    if not dataframe_list:
         return MetaFrame(
             data=[],
             convert_to_polars=lambda _: polars.DataFrame(),
@@ -134,7 +136,7 @@ def concat(dataframes: Iterable[MetaFrame], options: Iterable[MetaFrameOptions] 
         options = []
 
     return MetaFrame(
-        data=dataframes,
+        data=dataframe_list,
         convert_to_polars=lambda data: polars.concat(
             [df.to_polars() for df in data],
             **{

--- a/adapta/utils/metaframe.py
+++ b/adapta/utils/metaframe.py
@@ -123,7 +123,7 @@ def concat(dataframes: Iterable[MetaFrame], options: Iterable[MetaFrameOptions] 
     :return: Concatenated MetaFrame.
     """
 
-    if not [df for df in dataframes]:
+    if not list(dataframes):
         return MetaFrame(
             data=[],
             convert_to_polars=lambda _: polars.DataFrame(),

--- a/adapta/utils/metaframe.py
+++ b/adapta/utils/metaframe.py
@@ -137,7 +137,7 @@ def concat(dataframes: Iterable[MetaFrame], options: Iterable[MetaFrameOptions] 
 
     dataframes_iter = iter(dataframes)
     first = next(dataframes_iter, None)
-    if not first:
+    if first is None:
         return MetaFrame(
             data=[],
             convert_to_polars=lambda _: polars.DataFrame(),

--- a/tests/test_delta_load.py
+++ b/tests/test_delta_load.py
@@ -15,6 +15,7 @@
 
 import pathlib
 import zlib
+from copy import deepcopy
 from unittest.mock import patch, MagicMock, ANY, call
 
 import pandas
@@ -63,24 +64,24 @@ def test_delta_batch_load(get_client_and_path):
     client, data_path = get_client_and_path
     table = list(load(client, data_path, batch_size=10))
 
-    assert isinstance(table[0].to_pandas(), pandas.DataFrame)
-    assert isinstance(table[0].to_polars(), polars.DataFrame)
+    assert isinstance(deepcopy(table[0]).to_pandas(), pandas.DataFrame)
+    assert isinstance(deepcopy(table[0]).to_polars(), polars.DataFrame)
 
 
 def test_delta_filter(get_client_and_path):
     client, data_path = get_client_and_path
     table = load(client, data_path, row_filter=(pyarrow_field("A") == "b"))
 
-    assert len(table.to_pandas()) == 0
-    assert len(table.to_polars()) == 0
+    assert len(deepcopy(table).to_pandas()) == 0
+    assert len(deepcopy(table).to_polars()) == 0
 
 
 def test_column_project(get_client_and_path):
     client, data_path = get_client_and_path
     table = load(client, data_path, columns=["B"])
 
-    assert len(table.to_pandas().columns.to_list()) == 1
-    assert len(table.to_polars().columns) == 1
+    assert len(deepcopy(table).to_pandas().columns.to_list()) == 1
+    assert len(deepcopy(table).to_polars().columns) == 1
 
 
 def test_delta_load_with_partitions(get_client_and_path_partitioned):

--- a/tests/test_metaframe.py
+++ b/tests/test_metaframe.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 import pandas
 import polars
 
@@ -16,7 +18,6 @@ def test_to_df():
     assert metaframe.to_pandas().equals(pandas.DataFrame({"A": [1, 2, 3]}))
     assert metaframe.to_polars().equals(polars.DataFrame({"A": [1, 2, 3]}))
 
-
 def test_concat():
     """
     Test the concat method and the PandasOptions.
@@ -31,7 +32,30 @@ def test_concat():
         convert_to_pandas=lambda x: pandas.DataFrame.from_dict(x),
         convert_to_polars=lambda x: polars.from_dict(x),
     )
-    metaframe = concat([metaframe1, metaframe2], options=[PandasOptions(ignore_index=True)])
+    metaframe = concat(dataframes=[metaframe1, metaframe2], options=[PandasOptions(ignore_index=True)])
+    assert metaframe.to_pandas().equals(pandas.DataFrame({"A": [1, 2, 3, 4, 5, 6]}))
+    assert metaframe.to_polars().equals(polars.DataFrame({"A": [1, 2, 3, 4, 5, 6]}))
+
+
+def test_concat_with_generator():
+    """
+    Test the concat method with a generator instead of a list.
+    """
+    metaframe1 = MetaFrame(
+        data={"A": [1, 2, 3]},
+        convert_to_pandas=lambda x: pandas.DataFrame.from_dict(x),
+        convert_to_polars=lambda x: polars.from_dict(x),
+    )
+    metaframe2 = MetaFrame(
+        data={"A": [4, 5, 6]},
+        convert_to_pandas=lambda x: pandas.DataFrame.from_dict(x),
+        convert_to_polars=lambda x: polars.from_dict(x),
+    )
+
+    # Create a generator instead of a list
+    metaframes_generator = (mf for mf in [metaframe1, metaframe2])
+
+    metaframe = concat(metaframes_generator, options=[PandasOptions(ignore_index=True)])
     assert metaframe.to_pandas().equals(pandas.DataFrame({"A": [1, 2, 3, 4, 5, 6]}))
     assert metaframe.to_polars().equals(polars.DataFrame({"A": [1, 2, 3, 4, 5, 6]}))
 

--- a/tests/test_metaframe.py
+++ b/tests/test_metaframe.py
@@ -16,6 +16,7 @@ def test_to_df():
     assert metaframe.to_pandas().equals(pandas.DataFrame({"A": [1, 2, 3]}))
     assert metaframe.to_polars().equals(polars.DataFrame({"A": [1, 2, 3]}))
 
+
 def test_concat():
     """
     Test the concat method and the PandasOptions.

--- a/tests/test_metaframe.py
+++ b/tests/test_metaframe.py
@@ -1,5 +1,3 @@
-from collections.abc import Iterable
-
 import pandas
 import polars
 

--- a/tests/test_metaframe.py
+++ b/tests/test_metaframe.py
@@ -114,5 +114,7 @@ def test_materialized_check():
         convert_to_polars=lambda x: polars.from_dict(x),
     )
     assert metaframe.to_polars().equals(polars.DataFrame({"A": [1, 2, 3]}))
-    assert pytest.raises(RuntimeError, metaframe.to_polars)
-    assert pytest.raises(RuntimeError, metaframe.to_pandas)
+    with pytest.raises(RuntimeError):
+        metaframe.to_polars()
+    with pytest.raises(RuntimeError):
+        metaframe.to_pandas()

--- a/tests/test_metaframe.py
+++ b/tests/test_metaframe.py
@@ -36,6 +36,16 @@ def test_concat():
     assert metaframe.to_polars().equals(polars.DataFrame({"A": [1, 2, 3, 4, 5, 6]}))
 
 
+def test_empty_concat():
+    """
+    Test the concat method on empty dataframes.
+    """
+
+    metaframe = concat(dataframes=[])
+    assert metaframe.to_pandas().equals(pandas.DataFrame())
+    assert metaframe.to_polars().equals(polars.DataFrame())
+
+
 def test_from_df():
     """
     Test the from_pandas and from_polars methods.

--- a/tests/test_metaframe.py
+++ b/tests/test_metaframe.py
@@ -34,15 +34,15 @@ metaframe2 = MetaFrame(
     "dataframes,expected",
     [
         (
-            [metaframe1, metaframe2],  # list
+            [metaframe1.clone(), metaframe2.clone()],  # list
             polars.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
         ),
         (
-            (mf for mf in [metaframe1, metaframe2]),  # generator
+            (mf for mf in [metaframe1.clone(), metaframe2.clone()]),  # generator
             polars.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
         ),
         (
-            (metaframe1, metaframe2),  # tuple
+            (metaframe1.clone(), metaframe2.clone()),  # tuple
             polars.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
         ),
         ([], polars.DataFrame()),  # empty list
@@ -61,15 +61,15 @@ def test_concat_polars(dataframes, expected):
     "dataframes,expected",
     [
         (
-            [metaframe1, metaframe2],  # list
+            [metaframe1.clone(), metaframe2.clone()],  # list
             pandas.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
         ),
         (
-            (mf for mf in [metaframe1, metaframe2]),  # generator
+            (mf for mf in [metaframe1.clone(), metaframe2.clone()]),  # generator
             pandas.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
         ),
         (
-            (metaframe1, metaframe2),  # tuple
+            (metaframe1.clone(), metaframe2.clone()),  # tuple
             pandas.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
         ),
         (
@@ -85,6 +85,27 @@ def test_concat_pandas(dataframes, expected):
 
     metaframe = concat(dataframes=dataframes, options=[PandasOptions(ignore_index=True)])
     assert metaframe.to_pandas().equals(expected)
+
+
+@pytest.mark.parametrize(
+    "dataframes,expected_pandas, expected_polars",
+    [
+        (
+            [metaframe1.clone(), metaframe2.clone()],  # list
+            pandas.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
+            polars.DataFrame({"A": [1, 2, 3, 4, 5, 6]}),
+        ),
+    ],
+)
+def test_concat(dataframes, expected_pandas, expected_polars):
+    """
+    Test the concat method for pandas dataframes and the PandasOptions.
+    """
+
+    metaframe1_ = concat(dataframes=dataframes, options=[PandasOptions(ignore_index=True)])
+    metaframe2_ = metaframe1.clone()
+    assert metaframe1_.to_pandas().equals(expected_pandas)
+    assert metaframe2_.to_polars().equals(expected_polars)
 
 
 def test_from_df():

--- a/tests/test_serialization_format.py
+++ b/tests/test_serialization_format.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from copy import deepcopy
 
 import pytest
 import pandas
@@ -127,7 +128,7 @@ def test_unit_serialization(serializer: type[SerializationFormat], data: any):
     Tests that serializing and then immediately deserializing any data equals the original data.
     """
     if isinstance(data, MetaFrame):
-        assert data.to_pandas().equals(serializer().deserialize(serializer().serialize(data)).to_pandas())
+        assert deepcopy(data).to_pandas().equals(serializer().deserialize(serializer().serialize(data)).to_pandas())
     elif isinstance(data, pandas.DataFrame):
         assert data.equals(serializer().deserialize(serializer().serialize(data)))
     elif isinstance(data, polars.LazyFrame) | isinstance(data, polars.DataFrame):


### PR DESCRIPTION
### What
- Allow having empty lists in concat method by checking if there is an accessable item
- Added functionality to only allow calling to_pandas() and to_polars() once
- Fix all other unit tests

### Why
When an empty list of metaframes is trying to be concatenated, then the concat method fails. Here, we make sure that an empty dataframe is simply returned when the list is empty. 