### PR TITLE
Add init to VoidMetricsProvider

### DIFF
--- a/adapta/metrics/providers/void_provider.py
+++ b/adapta/metrics/providers/void_provider.py
@@ -12,6 +12,9 @@ class VoidMetricsProvider(MetricsProvider):
     Metrics provider that sends data into the void. Useful for testing.
     """
 
+    def __init__(self, **options):
+        pass
+
     def increment(self, metric_name: str, tags: dict[str, str] | None = None) -> None:
         pass
 


### PR DESCRIPTION
In Nexus SDK [here](https://github.com/SneaksAndData/nexus-sdk-py/blob/main/nexus_client_sdk/nexus/abstractions/metrics_provider_factory.py#L101), we init the metric provider with args, so we need this development. 