### PR TITLE
Make `MlflowBasicClient` overwrite env vars

### DIFF
--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -154,7 +154,7 @@ class MlflowBasicClient:
         )
 
     def transition_model_alias(
-            self, model_name: str, old_alias: str, new_alias: str, model_version: str | None
+        self, model_name: str, old_alias: str, new_alias: str, model_version: str | None
     ) -> None:
         """
         Mimics transition for model alias in Mlflow
@@ -167,12 +167,12 @@ class MlflowBasicClient:
         self.set_model_alias(model_name=model_name, alias=new_alias, model_version=model_version)
 
     def set_model_version_tag(
-            self,
-            model_name: str,
-            model_version: str | None = None,
-            key: str = None,
-            value: Any = None,
-            stage: str | None = None,
+        self,
+        model_name: str,
+        model_version: str | None = None,
+        key: str = None,
+        value: Any = None,
+        stage: str | None = None,
     ) -> None:
         """
         inherited the setting model version tag in Mlflow
@@ -218,10 +218,10 @@ class MlflowBasicClient:
         self._client.log_metric(run_id=run_id, key=metric_name, value=metric_value)
 
     def create_run(
-            self,
-            experiment_name: str,
-            run_name: str,
-            tags: dict[str, Any] | None = None,
+        self,
+        experiment_name: str,
+        run_name: str,
+        tags: dict[str, Any] | None = None,
     ) -> str:
         """
         inherited the creating run in Mlflow

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -42,10 +42,11 @@ class MlflowBasicClient:
         self._client = MlflowClient()
 
     @staticmethod
-    def _resolve_credentials(username: str | None, password: str | None):
+    def _resolve_credentials(username: str | None, password: str | None) -> None:
         """
-        Overwrite the environment variables for tracking username and tracking password if both are provided
-        if none or one provided, it will use the environment variables if any are defined.
+        Overwrite the environment variables for tracking username and tracking password if both are provided as
+        arguments. If only one of them is provided, an assertion error will occur.
+        If both are provided as environment variables, keep them as is.
         """
         assert not (
             (username is None) + (password is None) == 1

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -34,19 +34,30 @@ class MlflowBasicClient:
     Mlflow operations scoped to MlflowClient API.
     """
 
-    def __init__(self, tracking_server_uri: str, username: str | None, password: str | None):
-        if username:
+    def __init__(self, tracking_server_uri: str, username: str = None, password: str = None):
+        self._resolve_credentials(username=username, password=password)
+
+        mlflow.set_tracking_uri(tracking_server_uri)
+        self._tracking_server_uri = tracking_server_uri
+        self._client = MlflowClient()
+
+    @staticmethod
+    def _resolve_credentials(username: str | None, password: str | None):
+        """
+        Overwrite the environment variables for tracking username and tracking password if both are provided
+        if none or one provided, it will use the environment variables if any are defined.
+        """
+        assert not (
+            (username is None) + (password is None) == 1
+        ), "Both password and username must be set to access MLFlow Tracking Server, you only provided one of them."
+
+        if username and password:
             os.environ["MLFLOW_TRACKING_USERNAME"] = username
-        if password:
             os.environ["MLFLOW_TRACKING_PASSWORD"] = password
 
         assert os.environ.get("MLFLOW_TRACKING_USERNAME") and os.environ.get(
             "MLFLOW_TRACKING_PASSWORD"
         ), "Both MLFLOW_TRACKING_USERNAME and MLFLOW_TRACKING_PASSWORD must be set to access MLFlow Tracking Server"
-
-        mlflow.set_tracking_uri(tracking_server_uri)
-        self._tracking_server_uri = tracking_server_uri
-        self._client = MlflowClient()
 
     @property
     def tracking_server_uri(self) -> str:

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -34,7 +34,12 @@ class MlflowBasicClient:
     Mlflow operations scoped to MlflowClient API.
     """
 
-    def __init__(self, tracking_server_uri: str):
+    def __init__(self, tracking_server_uri: str, username: str | None, password: str | None):
+        if username:
+            os.environ["MLFLOW_TRACKING_USERNAME"] = username
+        if password:
+            os.environ["MLFLOW_TRACKING_PASSWORD"] = password
+
         assert os.environ.get("MLFLOW_TRACKING_USERNAME") and os.environ.get(
             "MLFLOW_TRACKING_PASSWORD"
         ), "Both MLFLOW_TRACKING_USERNAME and MLFLOW_TRACKING_PASSWORD must be set to access MLFlow Tracking Server"
@@ -149,7 +154,7 @@ class MlflowBasicClient:
         )
 
     def transition_model_alias(
-        self, model_name: str, old_alias: str, new_alias: str, model_version: str | None
+            self, model_name: str, old_alias: str, new_alias: str, model_version: str | None
     ) -> None:
         """
         Mimics transition for model alias in Mlflow
@@ -162,12 +167,12 @@ class MlflowBasicClient:
         self.set_model_alias(model_name=model_name, alias=new_alias, model_version=model_version)
 
     def set_model_version_tag(
-        self,
-        model_name: str,
-        model_version: str | None = None,
-        key: str = None,
-        value: Any = None,
-        stage: str | None = None,
+            self,
+            model_name: str,
+            model_version: str | None = None,
+            key: str = None,
+            value: Any = None,
+            stage: str | None = None,
     ) -> None:
         """
         inherited the setting model version tag in Mlflow
@@ -213,10 +218,10 @@ class MlflowBasicClient:
         self._client.log_metric(run_id=run_id, key=metric_name, value=metric_value)
 
     def create_run(
-        self,
-        experiment_name: str,
-        run_name: str,
-        tags: dict[str, Any] | None = None,
+            self,
+            experiment_name: str,
+            run_name: str,
+            tags: dict[str, Any] | None = None,
     ) -> str:
         """
         inherited the creating run in Mlflow


### PR DESCRIPTION
## Scope
Added support for providing password and username for mlflow when instanciating `MlflowBasicClient`. These will be used to set the environment variables used by mlflow.

This is done to ensure we can use the new dynaconf and provide secrets through one secret file - also for mlflow secrets
