### PR TITLE
Support static credentials for MLFlowBasicClient

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,4 +17,4 @@ jobs:
         uses: SneaksAndData/github-actions/semver_release@v0.1.11
         with:
           major_v: 3
-          minor_v: 5
+          minor_v: 6

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -38,6 +38,7 @@ class MlflowBasicClient:
 
     def __init__(self, tracking_server_uri: str):
         self._tracking_server_uri = tracking_server_uri
+        self._client: MlflowClient | None = None
 
     def _initialize(self) -> Self:
         mlflow.set_tracking_uri(self._tracking_server_uri)
@@ -75,7 +76,7 @@ class MlflowBasicClient:
         if os.path.exists(credentials_file_path):
             os.remove(credentials_file_path)
 
-        with open(credentials_file_location / "credentials", "w") as credentials_file:
+        with open(credentials_file_location / "credentials", "w", encoding="utf-8") as credentials_file:
             credentials_file_parser.write(credentials_file)
         return cls(tracking_server_uri=tracking_server_uri)._initialize()
 

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -72,11 +72,8 @@ class MlflowBasicClient:
         os.makedirs(credentials_file_location, exist_ok=True)
         credentials_file_parser = ConfigParser()
         credentials_file_parser["mlflow"] = {"mlflow_tracking_username": username, "mlflow_tracking_password": password}
-        # remove existing file if present
-        if os.path.exists(credentials_file_path):
-            os.remove(credentials_file_path)
 
-        with open(credentials_file_location / "credentials", "w", encoding="utf-8") as credentials_file:
+        with open(credentials_file_path, "w", encoding="utf-8") as credentials_file:
             credentials_file_parser.write(credentials_file)
         return cls(tracking_server_uri=tracking_server_uri)._initialize()
 

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -78,7 +78,12 @@ class MlflowBasicClient:
 
         with open(credentials_file_path, "w", encoding="utf-8") as credentials_file:
             credentials_file_parser.write(credentials_file)
-        return cls(tracking_server_uri=tracking_server_uri)._initialize()
+
+        # initialize and remove stored file
+        client = cls(tracking_server_uri=tracking_server_uri)._initialize()
+        os.remove(credentials_file_path)
+
+        return client
 
     @property
     def tracking_server_uri(self) -> str:

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -17,7 +17,7 @@
 #
 
 import os
-from configparser import ConfigParser
+from configparser import RawConfigParser
 from pathlib import Path
 from typing import Any, Self
 
@@ -70,8 +70,11 @@ class MlflowBasicClient:
         credentials_file_location = user_home / ".mlflow"
         credentials_file_path = credentials_file_location / "credentials"
         os.makedirs(credentials_file_location, exist_ok=True)
-        credentials_file_parser = ConfigParser()
-        credentials_file_parser["mlflow"] = {"mlflow_tracking_username": username, "mlflow_tracking_password": password}
+        credentials_file_parser = RawConfigParser()
+        credentials_file_parser["mlflow"] = {
+            "mlflow_tracking_username": username,
+            "mlflow_tracking_password": password.replace("%", "%%"),
+        }
 
         with open(credentials_file_path, "w", encoding="utf-8") as credentials_file:
             credentials_file_parser.write(credentials_file)

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -17,6 +17,7 @@
 #
 
 import os
+from configparser import ConfigParser
 from pathlib import Path
 from typing import Any, Self
 
@@ -68,17 +69,14 @@ class MlflowBasicClient:
         credentials_file_location = user_home / ".mlflow"
         credentials_file_path = credentials_file_location / "credentials"
         os.makedirs(credentials_file_location, exist_ok=True)
+        credentials_file_parser = ConfigParser()
+        credentials_file_parser["mlflow"] = {"mlflow_tracking_username": username, "mlflow_tracking_password": password}
         # remove existing file if present
         if os.path.exists(credentials_file_path):
             os.remove(credentials_file_path)
 
         with open(credentials_file_location / "credentials", "w") as credentials_file:
-            credentials_file.write(
-                f"""
-[mlflow]
-mlflow_tracking_username = {username}
-mlflow_tracking_password = {password}"""
-            )
+            credentials_file_parser.write(credentials_file)
         return cls(tracking_server_uri=tracking_server_uri)._initialize()
 
     @property

--- a/adapta/ml/mlflow/_client.py
+++ b/adapta/ml/mlflow/_client.py
@@ -17,7 +17,8 @@
 #
 
 import os
-from typing import Any
+from pathlib import Path
+from typing import Any, Self
 
 import mlflow
 from mlflow.entities.model_registry import ModelVersion
@@ -35,13 +36,50 @@ class MlflowBasicClient:
     """
 
     def __init__(self, tracking_server_uri: str):
+        self._tracking_server_uri = tracking_server_uri
+
+    def _initialize(self) -> Self:
+        mlflow.set_tracking_uri(self._tracking_server_uri)
+        self._client = MlflowClient()
+        return self
+
+    @classmethod
+    def from_environment_credentials(cls, tracking_server_uri: str) -> Self:
+        """
+        Creates an instance of MlflowBasicClient using credentials from environment variables
+        https://mlflow.org/docs/latest/self-hosting/security/basic-http-auth/#using-environment-variables
+        """
         assert os.environ.get("MLFLOW_TRACKING_USERNAME") and os.environ.get(
             "MLFLOW_TRACKING_PASSWORD"
         ), "Both MLFLOW_TRACKING_USERNAME and MLFLOW_TRACKING_PASSWORD must be set to access MLFlow Tracking Server"
 
-        mlflow.set_tracking_uri(tracking_server_uri)
-        self._tracking_server_uri = tracking_server_uri
-        self._client = MlflowClient()
+        return cls(tracking_server_uri=tracking_server_uri)._initialize()
+
+    @classmethod
+    def from_static_credentials(cls, tracking_server_uri: str, username: str, password: str) -> Self:
+        """
+        Creates an instance of MlflowBasicClient using credentials file generated from user-provided credentials
+        https://mlflow.org/docs/latest/self-hosting/security/basic-http-auth/#using-credentials-file
+
+        Use this method when you need to provision clients dynamically, or when working with multiple MLFlow instances.
+        This method is not thread-safe. Always call it from the main thread.
+        """
+        user_home = Path.home()
+        credentials_file_location = user_home / ".mlflow"
+        credentials_file_path = credentials_file_location / "credentials"
+        os.makedirs(credentials_file_location, exist_ok=True)
+        # remove existing file if present
+        if os.path.exists(credentials_file_path):
+            os.remove(credentials_file_path)
+
+        with open(credentials_file_location / "credentials", "w") as credentials_file:
+            credentials_file.write(
+                f"""
+[mlflow]
+mlflow_tracking_username = {username}
+mlflow_tracking_password = {password}"""
+            )
+        return cls(tracking_server_uri=tracking_server_uri)._initialize()
 
     @property
     def tracking_server_uri(self) -> str:


### PR DESCRIPTION
Closes https://github.com/SneaksAndData/adapta/issues/583

Added new class methods for instantiating the client using either environment variables or static credentials. Removed the option of creating a working instance via `MlflowBasicClient()` call, hence a minor bump.

**Authentication and Client Initialization Improvements:**

* Moved MLFlow setup logic out of `__init__` to a private `_initialize` method.
* Introduced `from_environment_credentials` class method to instantiate `MlflowBasicClient` using credentials from environment variables, with assertion for required variables, as in 3.5.x.
* Added `from_static_credentials` class method to instantiate `MlflowBasicClient` using a credentials file generated from provided username and password.

**AI Summary - edited**