### PR TITLE
Add support for specifying enum values for fields

### DIFF
--- a/adapta/dataclass_validation/dataclass/dataclass_abstract.py
+++ b/adapta/dataclass_validation/dataclass/dataclass_abstract.py
@@ -2,6 +2,7 @@
 Abstract Data Class
 """
 from copy import deepcopy
+from typing import Any
 
 import polars as pl
 
@@ -19,7 +20,7 @@ class AbstractDataClass(CoreDataClass):
     """
 
     def _validate_single_data(
-        self, data: any, settings: list[str], add_non_required_fields: bool
+        self, data: Any, settings: list[str], add_non_required_fields: bool
     ) -> ValidationResponse:
         """
         Method for validating the data against the schema.
@@ -36,7 +37,7 @@ class AbstractDataClass(CoreDataClass):
         return validation_response
 
     def validate_and_collect_data(
-        self, data: any, settings: list[str] = None, add_non_required_fields: bool = False
+        self, data: Any, settings: list[str] = None, add_non_required_fields: bool = False
     ) -> ValidationResponse:
         """
         Method for validating the data against the schema.
@@ -49,7 +50,7 @@ class AbstractDataClass(CoreDataClass):
             add_non_required_fields=add_non_required_fields,
         )
 
-    def validate_data(self, data: any, settings: list[str] = None, add_non_required_fields: bool = False) -> any:
+    def validate_data(self, data: Any, settings: list[str] = None, add_non_required_fields: bool = False) -> Any:
         """
         Method for validating the data against the schema.
         This method returns the updated data if the validation is successful.
@@ -72,7 +73,7 @@ class AbstractDataClass(CoreDataClass):
 
         return pl.DataFrame(schema=self.get_column_types())
 
-    def coerce_and_select_columns(self, data: any, coerce_all: bool = True) -> any:
+    def coerce_and_select_columns(self, data: Any, coerce_all: bool = True) -> Any:
         """
         Coerce the input data to match the schema and select only the columns defined in the schema.
         """

--- a/adapta/dataclass_validation/dataclass/dataclass_core.py
+++ b/adapta/dataclass_validation/dataclass/dataclass_core.py
@@ -1,6 +1,7 @@
 """
 Core data class implementation for the adapta library
 """
+from enum import Enum
 from typing import final
 
 
@@ -64,6 +65,8 @@ class Field:
         with None values with the correct dtype.
     9. checks: Check object to perform additional checks on the field (default is None).
     10. allow_missing_values: Whether missing values (e.g. None) are allowed (default is False).
+    11. enum: An optional Enum class whose member values define the allowed values for the field (default is None).
+        Only enum member values matching the field's dtype are enforced during validation.
     """
 
     # pylint: disable=too-many-arguments, too-many-instance-attributes
@@ -80,6 +83,7 @@ class Field:
         checks: Checks = None,
         allow_missing_values: bool = False,
         astra_properties: AstraProperties = None,
+        enum: type[Enum] = None,
     ):
         self.display_name = display_name
         self.description = description
@@ -92,6 +96,10 @@ class Field:
         self.checks = checks
         self.allow_missing_values = allow_missing_values
         self.astra_properties = astra_properties
+        self.enum = enum
+
+        if self.enum is not None and not (isinstance(self.enum, type) and issubclass(self.enum, Enum)):
+            raise ValueError("The 'enum' parameter must be an Enum class (not an instance).")
 
         if self.checks is not None and self.dtype not in [int, float, list[int], list[float]]:
             if self.checks.le_value is not None or self.checks.ge_value is not None:
@@ -130,6 +138,7 @@ class CoreDataClass:
         self._set_ge_value_fields()
         self._set_le_value_fields()
         self._set_not_allowed_missing_value_fields()
+        self._set_enum_fields()
         self._set_astra_properties_keys()
 
     def _set_fields(self) -> None:
@@ -240,6 +249,14 @@ class CoreDataClass:
             field_name: field for field_name, field in self.get_fields().items() if not field.allow_missing_values
         }
 
+    def _set_enum_fields(self) -> None:
+        """
+        Set the fields that have an enum constraint.
+        """
+        self._enum_fields = {
+            field_name: field for field_name, field in self.get_fields().items() if field.enum is not None
+        }
+
     def get_fields(self) -> dict[str, Field]:
         """
         Get the fields of the data class.
@@ -319,6 +336,12 @@ class CoreDataClass:
         Get the fields that do not allow missing values.
         """
         return self._not_allowed_missing_value_fields
+
+    def get_enum_fields(self) -> dict[str, Field]:
+        """
+        Get the fields that have an enum constraint.
+        """
+        return self._enum_fields
 
     def get_columns(self) -> list[str]:
         """

--- a/adapta/dataclass_validation/validation/validation_abstract.py
+++ b/adapta/dataclass_validation/validation/validation_abstract.py
@@ -2,7 +2,7 @@
 Abstract Validation Class
 """
 from abc import abstractmethod
-from typing import get_origin, get_args
+from typing import Any, get_origin, get_args
 
 from adapta.dataclass_validation.dataclass.dataclass_core import CoreDataClass, Field
 from adapta.dataclass_validation.validation.validation_utils import ValidationResponse
@@ -13,7 +13,7 @@ class AbstractValidationClass:
     Abstract Validation Class
     """
 
-    def __init__(self, data: any, schema: CoreDataClass, settings: list[str], add_non_required_fields: bool = False):
+    def __init__(self, data: Any, schema: CoreDataClass, settings: list[str], add_non_required_fields: bool = False):
         self._data = data
         self._schema = schema
         self._settings = settings
@@ -61,7 +61,7 @@ class AbstractValidationClass:
         Abstract method for validating primary keys.
         """
 
-    def _get_expected_dtypes(self, dtype: type) -> any:
+    def _get_expected_dtypes(self, dtype: type) -> Any:
         """
         Method to get the expected data types for the fields. If the type is a list, we use recursion to get the
         expected type.
@@ -100,7 +100,7 @@ class AbstractValidationClass:
         """
 
     @abstractmethod
-    def _get_column_dtype(self, column_name: str) -> any:
+    def _get_column_dtype(self, column_name: str) -> Any:
         """
         Abstract method to get the data type of a specific column.
         """
@@ -112,7 +112,7 @@ class AbstractValidationClass:
         """
 
     @abstractmethod
-    def _cast_column(self, column_name: str, dtype: any) -> None:
+    def _cast_column(self, column_name: str, dtype: Any) -> None:
         """
         Abstract method for casting a column to a specific type.
         """
@@ -307,7 +307,7 @@ class AbstractValidationClass:
 
     @abstractmethod
     def _get_invalid_enum_members(
-        self, column_name: str, enum_members: list, dtype: type, allow_missing_values: bool
+        self, column_name: str, enum_members: list[Any], dtype: type, allow_missing_values: bool
     ) -> list:
         """
         Abstract method to find column values that are not valid enum members.
@@ -325,8 +325,6 @@ class AbstractValidationClass:
         Validate that column values belong to the set of allowed enum member values.
         """
         for field_name, field in self._schema.get_enum_fields().items():
-            if field.enum is None:
-                continue
             if self._should_validate_field(field_name=field_name):
                 enum_member_values = [member.value for member in field.enum]
                 invalid_values = self._get_invalid_enum_members(
@@ -374,20 +372,20 @@ class AbstractValidationClass:
             failed_validations=self._failed_validations,
         )
 
-    def get_data(self) -> any:
+    def get_data(self) -> Any:
         """
         Get the data for all columns
         """
         return self._data
 
     @abstractmethod
-    def get_data_for_columns(self) -> any:
+    def get_data_for_columns(self) -> Any:
         """
         Get the data and select all columns.
         """
 
     @abstractmethod
-    def get_data_for_required_columns(self) -> any:
+    def get_data_for_required_columns(self) -> Any:
         """
         Get the data and select required columns.
         """

--- a/adapta/dataclass_validation/validation/validation_abstract.py
+++ b/adapta/dataclass_validation/validation/validation_abstract.py
@@ -305,6 +305,42 @@ class AbstractValidationClass:
                     f"Column '{field_name}' does not allow missing values but contains missing values."
                 ]
 
+    @abstractmethod
+    def _get_invalid_enum_members(
+        self, column_name: str, enum_members: list, dtype: type, allow_missing_values: bool
+    ) -> list:
+        """
+        Abstract method to find column values that are not valid enum members.
+
+        :param column_name: The name of the column to check.
+        :param enum_members: The list of enum member values for the column.
+        :param dtype: The Python type of the field, used to filter enum members to matching types.
+        :param allow_missing_values: Whether null values are allowed for the column. If True, nulls are excluded
+            from the check. If False, nulls are treated as invalid enum members.
+        :return: A list of invalid values found in the column.
+        """
+
+    def _validate_enum_members(self) -> None:
+        """
+        Validate that column values belong to the set of allowed enum member values.
+        """
+        for field_name, field in self._schema.get_enum_fields().items():
+            if field.enum is None:
+                continue
+            if self._should_validate_field(field_name=field_name):
+                enum_member_values = [member.value for member in field.enum]
+                invalid_values = self._get_invalid_enum_members(
+                    column_name=field_name,
+                    enum_members=enum_member_values,
+                    dtype=field.dtype,
+                    allow_missing_values=field.allow_missing_values,
+                )
+                if invalid_values:
+                    self._failed_validations += [
+                        f"Column '{field_name}' contains values that are not members of "
+                        f"{field.enum.__name__}. Invalid values found: {invalid_values}"
+                    ]
+
     def _set_failed_validations(self) -> None:
         self._add_missing_fields()
         self._validate_missing_fields()
@@ -323,6 +359,7 @@ class AbstractValidationClass:
         self._validate_ge_value()
         self._validate_le_value()
         self._validate_value_not_missing()
+        self._validate_enum_members()
 
     def validate(self) -> ValidationResponse:
         """

--- a/adapta/dataclass_validation/validation/validation_polars.py
+++ b/adapta/dataclass_validation/validation/validation_polars.py
@@ -2,6 +2,7 @@
 Validation class for Polars DataFrames.
 """
 import datetime
+from typing import Any
 
 import polars as pl
 
@@ -48,7 +49,7 @@ class PolarsValidationClass(AbstractValidationClass):
                 f"primary key(s): {primary_keys}"
             ]
 
-    def _get_column_dtype(self, column_name: str) -> any:
+    def _get_column_dtype(self, column_name: str) -> Any:
         return self._data[column_name].dtype
 
     def _get_dataframe_columns(self) -> list[str]:

--- a/adapta/dataclass_validation/validation/validation_polars.py
+++ b/adapta/dataclass_validation/validation/validation_polars.py
@@ -91,6 +91,28 @@ class PolarsValidationClass(AbstractValidationClass):
     def _are_values_not_missing(self, column_name: str) -> bool:
         return self._data.filter(pl.col(column_name).is_null()).is_empty()
 
+    def _get_invalid_enum_members(
+        self, column_name: str, enum_members: list, dtype: type, allow_missing_values: bool
+    ) -> list:
+        """
+        Find column values that are not valid enum members.
+
+        :param column_name: The name of the column to check.
+        :param enum_members: The list of enum member values for the column.
+        :param dtype: The Python type of the field, used to filter enum members to matching types.
+        :param allow_missing_values: Whether null values are allowed for the column. If True, nulls are excluded
+            from the check. If False, nulls are treated as invalid enum members.
+        :return: A list of invalid values found in the column, empty if all values are valid.
+        """
+        dtype_enum_members = [value for value in enum_members if isinstance(value, dtype)]
+        invalid_condition = ~pl.col(column_name).is_in(dtype_enum_members)
+        if allow_missing_values:
+            invalid_condition = invalid_condition & pl.col(column_name).is_not_null()
+        invalid = self._data.filter(invalid_condition)
+        if invalid.is_empty():
+            return []
+        return invalid[column_name].unique().to_list()
+
     def _are_list_values_ge(self, column_name: str, ge_value: float, tolerance: float) -> float | None:
         """
         Check if all elements within a list column are greater than or equal to the specified value,

--- a/tests/dataclass_validation/validation/abstract_or_validation_class/test_validate_allowed_values.py
+++ b/tests/dataclass_validation/validation/abstract_or_validation_class/test_validate_allowed_values.py
@@ -1,0 +1,201 @@
+"""
+Tests for the enum field validation.
+"""
+from dataclasses import dataclass
+from enum import Enum
+
+import polars as pl
+import pytest
+
+from adapta.dataclass_validation import AbstractDataClass, Field
+
+
+class MixedEnum(Enum):
+    """Enum with mixed-type member values for testing dtype filtering."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    CODE_ONE = 1
+    SCORE = 2.0
+
+
+class PriorityEnum(Enum):
+    """Enum with mixed-type member values for priority testing."""
+
+    HIGH = "high"
+    LOW = 1
+    MEDIUM = 2
+    THRESHOLD = 3.5
+
+
+class EnumDataClass(AbstractDataClass):
+    """Schema with fields that have enum constraints."""
+
+    status = Field(
+        display_name="Status",
+        description="Status field with string allowed values from a mixed enum.",
+        dtype=str,
+        enum=MixedEnum,
+    )
+    priority = Field(
+        display_name="Priority",
+        description="Priority field with int allowed values from a mixed enum.",
+        dtype=int,
+        enum=PriorityEnum,
+    )
+    score = Field(
+        display_name="Score",
+        description="Score field without an enum constraint.",
+        dtype=float,
+    )
+    nullable_status = Field(
+        display_name="Nullable Status",
+        description="Nullable status field where missing values are allowed.",
+        dtype=str,
+        enum=MixedEnum,
+        allow_missing_values=True,
+    )
+    strict_status = Field(
+        display_name="Strict Status",
+        description="Strict status field where missing values are not allowed.",
+        dtype=str,
+        enum=MixedEnum,
+        allow_missing_values=False,
+    )
+
+
+SCHEMA = EnumDataClass()
+
+
+@dataclass
+class InputTest:
+    """Input data for the test."""
+
+    data: pl.DataFrame
+
+
+@dataclass
+class OutputTest:
+    """Expected output for the test."""
+
+    should_pass: bool
+    expected_invalid_column: str = None
+
+
+@pytest.mark.parametrize(
+    ("inputs", "expected"),
+    [
+        pytest.param(
+            InputTest(
+                data=pl.DataFrame(
+                    {
+                        SCHEMA.status: ["active", "inactive"],
+                        SCHEMA.priority: pl.Series([1, 2], dtype=pl.Int64),
+                        SCHEMA.score: [1.0, 2.0],
+                        SCHEMA.nullable_status: ["active", "inactive"],
+                        SCHEMA.strict_status: ["active", "inactive"],
+                    }
+                ),
+            ),
+            OutputTest(should_pass=True),
+            id="1) All values within allowed enum sets",
+        ),
+        pytest.param(
+            InputTest(
+                data=pl.DataFrame(
+                    {
+                        SCHEMA.status: ["active", "unknown"],
+                        SCHEMA.priority: pl.Series([1, 2], dtype=pl.Int64),
+                        SCHEMA.score: [1.0, 2.0],
+                        SCHEMA.nullable_status: ["active", "inactive"],
+                        SCHEMA.strict_status: ["active", "inactive"],
+                    }
+                ),
+            ),
+            OutputTest(should_pass=False, expected_invalid_column="status"),
+            id="2) String column contains value not in enum",
+        ),
+        pytest.param(
+            InputTest(
+                data=pl.DataFrame(
+                    {
+                        SCHEMA.status: ["active", "inactive"],
+                        SCHEMA.priority: pl.Series([1, 99], dtype=pl.Int64),
+                        SCHEMA.score: [1.0, 2.0],
+                        SCHEMA.nullable_status: ["active", "inactive"],
+                        SCHEMA.strict_status: ["active", "inactive"],
+                    }
+                ),
+            ),
+            OutputTest(should_pass=False, expected_invalid_column="priority"),
+            id="3) Int column contains value not in dtype-filtered enum",
+        ),
+        pytest.param(
+            InputTest(
+                data=pl.DataFrame(
+                    {
+                        SCHEMA.status: ["active", "inactive"],
+                        SCHEMA.priority: pl.Series([1, 2], dtype=pl.Int64),
+                        SCHEMA.score: [999.0, 2.0],
+                        SCHEMA.nullable_status: ["active", "inactive"],
+                        SCHEMA.strict_status: ["active", "inactive"],
+                    }
+                ),
+            ),
+            OutputTest(should_pass=True),
+            id="4) Column without enum is not validated",
+        ),
+        pytest.param(
+            InputTest(
+                data=pl.DataFrame(
+                    {
+                        SCHEMA.status: ["active", "inactive"],
+                        SCHEMA.priority: pl.Series([1, 2], dtype=pl.Int64),
+                        SCHEMA.score: [1.0, 2.0],
+                        SCHEMA.nullable_status: pl.Series(["active", None], dtype=pl.String),
+                        SCHEMA.strict_status: ["active", "inactive"],
+                    }
+                ),
+            ),
+            OutputTest(should_pass=True),
+            id="5) Nulls in a nullable enum field are accepted",
+        ),
+        pytest.param(
+            InputTest(
+                data=pl.DataFrame(
+                    {
+                        SCHEMA.status: ["active", "inactive"],
+                        SCHEMA.priority: pl.Series([1, 2], dtype=pl.Int64),
+                        SCHEMA.score: [1.0, 2.0],
+                        SCHEMA.nullable_status: ["active", "inactive"],
+                        SCHEMA.strict_status: pl.Series(["active", None], dtype=pl.String),
+                    }
+                ),
+            ),
+            OutputTest(should_pass=False, expected_invalid_column="strict_status"),
+            id="6) Nulls in a non-nullable enum field are treated as invalid",
+        ),
+    ],
+)
+def test__validate_enum_members__unit_test(inputs: InputTest, expected: OutputTest):
+    """
+    Test enum validation logic:
+
+    * 1) Validates that all values pass when within the dtype-filtered enum member values.
+    * 2) Detects invalid string values not present in the enum.
+    * 3) Filters enum member values by dtype so only int members from a mixed enum are checked.
+    * 4) Columns without an enum constraint are unaffected by the validation.
+    * 5) Null values in a nullable enum field are excluded from the enum membership check.
+    * 6) Null values in a non-nullable enum field are reported as invalid enum members.
+    """
+    # Act
+    validation_response = SCHEMA.validate_and_collect_data(data=inputs.data)
+
+    # Assert
+    if expected.should_pass:
+        assert (
+            len(validation_response.failed_validations) == 0
+        ), f"Expected no failures but got: {validation_response.failed_validations}"
+    else:
+        assert len(validation_response.failed_validations) > 0
+        assert any(expected.expected_invalid_column in msg for msg in validation_response.failed_validations)


### PR DESCRIPTION
Fixes/Implements #<issue number>.

## Scope

Implemented:
Added support to specify "enum" as an input to a field. Validation will check that the columns rows with have values that falls into the enums members.



## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
