### PR TITLE
fix: remove -x from set -euxo pipefail to prevent secret leakage

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -30,10 +30,10 @@ jobs:
         env:
           PROJECT_NAME: adapta
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           find "$PROJECT_NAME" -type f -name "*.py" | xargs poetry run pylint
 
       - name: Black
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           poetry run black . --check --diff

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Unit test
         run: |
-          set -euxo pipefail
+          set -euo pipefail
 
           poetry run pytest ./tests --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=term-missing:skip-covered | tee pytest-coverage.txt
 


### PR DESCRIPTION
## Summary

Removes the `-x` flag from `set -euxo pipefail` to prevent secrets from being printed in GitHub Actions logs.

The `-x` flag causes bash to print each command before executing it, which can expose secret values that are passed as environment variables or arguments.

## Related Issue

Closes SneaksAndData/terraform#7626

## Changes

- Replaced `set -euxo pipefail` with `set -euo pipefail` in affected workflow files
