### PR TITLE
[Snowflake] Update SnowflakeClient to comply with Snowflakes key-pair auth req

### DIFF
--- a/adapta/storage/database/v3/models/_models.py
+++ b/adapta/storage/database/v3/models/_models.py
@@ -50,3 +50,11 @@ class DatabaseType(Enum):
         },
     )
     SQLITE_ODBC = SqlAlchemyDialect(dialect="sqlite+pysqlite", driver={})
+
+
+class SnowflakeAuth(str, Enum):
+    """Supported Snowflake authentication options."""
+
+    SNOWFLAKE = "snowflake"
+    EXTERNAL_BROWSER = "externalbrowser"
+    KEY_PAIR = "SNOWFLAKE_JWT"

--- a/adapta/storage/database/v3/models/_models.py
+++ b/adapta/storage/database/v3/models/_models.py
@@ -55,6 +55,5 @@ class DatabaseType(Enum):
 class SnowflakeAuth(str, Enum):
     """Supported Snowflake authentication options."""
 
-    SNOWFLAKE = "snowflake"
     EXTERNAL_BROWSER = "externalbrowser"
     KEY_PAIR = "SNOWFLAKE_JWT"

--- a/adapta/storage/database/v3/models/_models.py
+++ b/adapta/storage/database/v3/models/_models.py
@@ -18,6 +18,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import final
 
 
 @dataclass
@@ -58,3 +59,4 @@ class SnowflakeAuth(str, Enum):
 
     EXTERNAL_BROWSER = "externalbrowser"
     KEY_PAIR = "SNOWFLAKE_JWT"
+    PASSWORD = "snowflake"

--- a/adapta/storage/database/v3/models/_models.py
+++ b/adapta/storage/database/v3/models/_models.py
@@ -52,6 +52,7 @@ class DatabaseType(Enum):
     SQLITE_ODBC = SqlAlchemyDialect(dialect="sqlite+pysqlite", driver={})
 
 
+@final
 class SnowflakeAuth(str, Enum):
     """Supported Snowflake authentication options."""
 

--- a/adapta/storage/database/v3/snowflake_sql.py
+++ b/adapta/storage/database/v3/snowflake_sql.py
@@ -66,7 +66,6 @@ class SnowflakeClient:
         ),
         role: str | None = None,
     ):
-
         if private_key:
             self._authenticator = SnowflakeAuth.KEY_PAIR
         elif password:

--- a/adapta/storage/database/v3/snowflake_sql.py
+++ b/adapta/storage/database/v3/snowflake_sql.py
@@ -22,6 +22,20 @@ from adapta.utils.metaframe import MetaFrame
 from adapta.storage.database.v3.models import SnowflakeAuth
 
 
+def load_private_key(private_key: str, private_key_password: str | None = None) -> RSAPrivateKey:
+    """
+    Loads a PEM RSA private key.
+    """
+    pem_bytes = private_key.encode("utf-8")
+    pem_password_bytes = private_key_password.encode("utf-8") if private_key_password else None
+    loaded_key = load_pem_private_key(pem_bytes, password=pem_password_bytes)
+    if not isinstance(loaded_key, RSAPrivateKey):
+        raise ValueError(
+            f"Snowflake key-pair authentication requires an RSA private key, got {type(loaded_key).__name__}"
+        )
+    return loaded_key
+
+
 class SnowflakeClient:
     """
     A wrapper around the Snowflake Python connector that provides a context manager for handling connections
@@ -30,11 +44,9 @@ class SnowflakeClient:
     :param user: The username for the Snowflake account.
     :param account: The account name for the Snowflake account.
     :param warehouse: The warehouse name for the Snowflake account.
-    :param authenticator: The authentication mechanism to use for the Snowflake account.
-    :param logger: The logger to use for logging messages. Defaults to a new SemanticLogger instance.
-    :param password: Optional - The password for the Snowflake user. Should be combined with `authenticator='snowflake'` to enable password authentication
-    :param private_key: Optional - The private key for the Snowflake user.
+    :param private_key: Optional - The private key for the Snowflake user (assumes PEM).
     :param private_key_password: Optional - The password for the private key, if it is encrypted.
+    :param logger: The logger to use for logging messages. Defaults to a new SemanticLogger instance.
     :param role: Optional - The role for the Snowflake user.
     """
 
@@ -43,55 +55,28 @@ class SnowflakeClient:
         user: str,
         account: str,
         warehouse: str,
-        authenticator: str = SnowflakeAuth.EXTERNAL_BROWSER,
+        private_key: str | None = None,
+        private_key_password: str | None = None,
         logger: SemanticLogger = SemanticLogger().add_log_source(
             log_source_name="adapta-snowflake-client",
             min_log_level=LogLevel.INFO,
             is_default=True,
         ),
-        password: str | None = None,
-        private_key: str | None = None,
-        private_key_password: str | None = None,
         role: str | None = None,
     ):
-        if password and private_key:
-            raise ValueError("Provide either password or private_key, not both")
-
+        if not private_key:
+            logger.warning(
+                "No private key provided for {account} -- falling back to externalbrowser authentication.",
+                account=account,
+            )
         self._user = user
         self._account = account
         self._warehouse = warehouse
         self._logger = logger
-        self._password = password
-        self._private_key = self._load_private_key(private_key, private_key_password) if private_key else None
-        self._authenticator = self._resolve_auth(authenticator, password, private_key)
+        self._private_key = load_private_key(private_key, private_key_password) if private_key else None
+        self._authenticator = SnowflakeAuth.KEY_PAIR if private_key else SnowflakeAuth.EXTERNAL_BROWSER
         self._role = role
         self._conn = None
-
-    @staticmethod
-    def _resolve_auth(authenticator: str, password: str | None, private_key: str | None) -> str:
-        """
-        Select appropriate auth method for Snowflake.
-        """
-        if private_key:
-            return SnowflakeAuth.KEY_PAIR
-        if password:
-            return SnowflakeAuth.SNOWFLAKE
-        return authenticator
-
-    @staticmethod
-    def _load_private_key(private_key: str, private_key_password: str | None = None) -> RSAPrivateKey:
-        """
-        Loads a PEM RSA private key.
-        """
-        pem_bytes = private_key.encode("utf-8")
-        pem_password_bytes = private_key_password.encode("utf-8") if private_key_password else None
-        loaded_key = load_pem_private_key(pem_bytes, password=pem_password_bytes)
-        if not isinstance(loaded_key, RSAPrivateKey):
-            raise ValueError(
-                f"Snowflake key-pair authentication requires an RSA private key, got {type(loaded_key).__name__}"
-            )
-        return loaded_key
-
 
     def __enter__(self) -> Self | None:
         """
@@ -103,11 +88,9 @@ class SnowflakeClient:
                 user=self._user,
                 account=self._account,
                 warehouse=self._warehouse,
-                password=self._password,
                 private_key=self._private_key,
                 authenticator=self._authenticator,
                 role=self._role,
-
             )
             return self
         except DatabaseError as ex:

--- a/adapta/storage/database/v3/snowflake_sql.py
+++ b/adapta/storage/database/v3/snowflake_sql.py
@@ -6,6 +6,8 @@ import os
 import re
 from types import TracebackType
 from typing import Self
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 
 import snowflake.connector
 
@@ -17,6 +19,7 @@ from adapta.storage.models import S3Path, DataPath
 
 from adapta.storage.models.azure import AdlsGen2Path
 from adapta.utils.metaframe import MetaFrame
+from adapta.storage.database.v3.models import SnowflakeAuth
 
 
 class SnowflakeClient:
@@ -30,6 +33,8 @@ class SnowflakeClient:
     :param authenticator: The authentication mechanism to use for the Snowflake account.
     :param logger: The logger to use for logging messages. Defaults to a new SemanticLogger instance.
     :param password: Optional - The password for the Snowflake user. Should be combined with `authenticator='snowflake'` to enable password authentication
+    :param private_key: Optional - The private key for the Snowflake user.
+    :param private_key_password: Optional - The password for the private key, if it is encrypted.
     :param role: Optional - The role for the Snowflake user.
     """
 
@@ -38,23 +43,55 @@ class SnowflakeClient:
         user: str,
         account: str,
         warehouse: str,
-        authenticator: str = "externalbrowser",
+        authenticator: str = SnowflakeAuth.EXTERNAL_BROWSER,
         logger: SemanticLogger = SemanticLogger().add_log_source(
             log_source_name="adapta-snowflake-client",
             min_log_level=LogLevel.INFO,
             is_default=True,
         ),
         password: str | None = None,
+        private_key: str | None = None,
+        private_key_password: str | None = None,
         role: str | None = None,
     ):
+        if password and private_key:
+            raise ValueError("Provide either password or private_key, not both")
+
         self._user = user
         self._account = account
         self._warehouse = warehouse
-        self._authenticator = "snowflake" if password else authenticator
         self._logger = logger
         self._password = password
+        self._private_key = self._load_private_key(private_key, private_key_password) if private_key else None
+        self._authenticator = self._resolve_auth(authenticator, password, private_key)
         self._role = role
         self._conn = None
+
+    @staticmethod
+    def _resolve_auth(authenticator: str, password: str | None, private_key: str | None) -> str:
+        """
+        Select appropriate auth method for Snowflake.
+        """
+        if private_key:
+            return SnowflakeAuth.KEY_PAIR
+        if password:
+            return SnowflakeAuth.SNOWFLAKE
+        return authenticator
+
+    @staticmethod
+    def _load_private_key(private_key: str, private_key_password: str | None = None) -> RSAPrivateKey:
+        """
+        Loads a PEM RSA private key.
+        """
+        pem_bytes = private_key.encode("utf-8")
+        pem_password_bytes = private_key_password.encode("utf-8") if private_key_password else None
+        loaded_key = load_pem_private_key(pem_bytes, password=pem_password_bytes)
+        if not isinstance(loaded_key, RSAPrivateKey):
+            raise ValueError(
+                f"Snowflake key-pair authentication requires an RSA private key, got {type(loaded_key).__name__}"
+            )
+        return loaded_key
+
 
     def __enter__(self) -> Self | None:
         """
@@ -65,10 +102,12 @@ class SnowflakeClient:
             self._conn = snowflake.connector.connect(
                 user=self._user,
                 account=self._account,
-                password=self._password,
                 warehouse=self._warehouse,
+                password=self._password,
+                private_key=self._private_key,
                 authenticator=self._authenticator,
                 role=self._role,
+
             )
             return self
         except DatabaseError as ex:

--- a/adapta/storage/database/v3/snowflake_sql.py
+++ b/adapta/storage/database/v3/snowflake_sql.py
@@ -46,6 +46,7 @@ class SnowflakeClient:
     :param warehouse: The warehouse name for the Snowflake account.
     :param private_key: Optional - The private key for the Snowflake user (assumes PEM).
     :param private_key_password: Optional - The password for the private key, if it is encrypted.
+    :param password: Optional - Plain-text password for the Snowflake user. Ignored if private_key is set.
     :param logger: The logger to use for logging messages. Defaults to a new SemanticLogger instance.
     :param role: Optional - The role for the Snowflake user.
     """
@@ -57,6 +58,7 @@ class SnowflakeClient:
         warehouse: str,
         private_key: str | None = None,
         private_key_password: str | None = None,
+        password: str | None = None,
         logger: SemanticLogger = SemanticLogger().add_log_source(
             log_source_name="adapta-snowflake-client",
             min_log_level=LogLevel.INFO,
@@ -64,9 +66,15 @@ class SnowflakeClient:
         ),
         role: str | None = None,
     ):
-        if not private_key:
+
+        if private_key:
+            self._authenticator = SnowflakeAuth.KEY_PAIR
+        elif password:
+            self._authenticator = SnowflakeAuth.PASSWORD
+        else:
+            self._authenticator = SnowflakeAuth.EXTERNAL_BROWSER
             logger.warning(
-                "No private key provided for {account} -- falling back to externalbrowser authentication.",
+                "No private key / password provided for {account} -- falling back to externalbrowser authentication.",
                 account=account,
             )
         self._user = user
@@ -74,7 +82,7 @@ class SnowflakeClient:
         self._warehouse = warehouse
         self._logger = logger
         self._private_key = load_private_key(private_key, private_key_password) if private_key else None
-        self._authenticator = SnowflakeAuth.KEY_PAIR if private_key else SnowflakeAuth.EXTERNAL_BROWSER
+        self._password = password
         self._role = role
         self._conn = None
 
@@ -89,6 +97,7 @@ class SnowflakeClient:
                 account=self._account,
                 warehouse=self._warehouse,
                 private_key=self._private_key,
+                password=self._password,
                 authenticator=self._authenticator,
                 role=self._role,
             )

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -17,8 +17,11 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 from deltalake import DeltaTable
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
 
-from adapta.storage.database.v3.snowflake_sql import SnowflakeClient
+from adapta.storage.database.v3.snowflake_sql import SnowflakeClient, load_private_key
+from adapta.storage.database.v3.models import SnowflakeAuth
 
 from adapta.storage.models.azure import AdlsGen2Path
 
@@ -144,3 +147,54 @@ def test_publish_external_delta_table_skip_initialize(
     mock_query.assert_any_call(
         query='alter external table "test_database"."test_schema"."test_table" refresh;', fetch_dataframe=False
     )
+
+
+def serialize_to_pem_key(rsa_private_key_test: rsa.RSAPrivateKey, passphrase: str | None = None) -> str:
+    encryption = (
+        serialization.BestAvailableEncryption(passphrase.encode("utf-8"))
+        if passphrase
+        else serialization.NoEncryption()
+    )
+    return rsa_private_key_test.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=encryption,
+    ).decode("utf-8")
+
+
+def test_load_private_key_unencrypted():
+    test_rsa_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)  # create an RSA key
+    serialized_pem_private_key = serialize_to_pem_key(test_rsa_private_key, passphrase=None)  # serialize to PEM
+    loaded_key = load_private_key(serialized_pem_private_key)  # test
+    assert isinstance(loaded_key, rsa.RSAPrivateKey)
+    assert loaded_key.private_numbers() == test_rsa_private_key.private_numbers()
+
+
+def test_load_private_key_encrypted():
+    test_rsa_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)  # create an RSA key
+    serialized_pem_private_key = serialize_to_pem_key(
+        test_rsa_private_key, passphrase="test_password"
+    )  # serialize to PEM
+    loaded_key = load_private_key(private_key=serialized_pem_private_key, private_key_password="test_password")  # test
+    assert isinstance(loaded_key, rsa.RSAPrivateKey)
+    assert loaded_key.private_numbers() == test_rsa_private_key.private_numbers()
+
+
+def test_client_uses_key_pair_when_private_key_supplied():
+    test_rsa_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    snowflake_client = SnowflakeClient(
+        user="test_user",
+        account="test_account",
+        warehouse="test_warehouse",
+        private_key=serialize_to_pem_key(test_rsa_private_key),
+    )
+
+    assert snowflake_client._authenticator == SnowflakeAuth.KEY_PAIR
+    assert isinstance(snowflake_client._private_key, rsa.RSAPrivateKey)
+
+
+def test_client_falls_back_to_external_browser_without_private_key():
+    snowflake_client = SnowflakeClient(user="test_user", account="test_account", warehouse="test_warehouse")
+    assert snowflake_client._authenticator == SnowflakeAuth.EXTERNAL_BROWSER
+    assert snowflake_client._private_key is None

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -198,3 +198,15 @@ def test_client_falls_back_to_external_browser_without_private_key():
     snowflake_client = SnowflakeClient(user="test_user", account="test_account", warehouse="test_warehouse")
     assert snowflake_client._authenticator == SnowflakeAuth.EXTERNAL_BROWSER
     assert snowflake_client._private_key is None
+
+def test_key_pair_precedence():
+    test_rsa_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    snowflake_client = SnowflakeClient(
+        user="test_user",
+        account="test_account",
+        warehouse="test_warehouse",
+        private_key=serialize_to_pem_key(test_rsa_private_key),
+        password="test_password",
+    )
+    assert snowflake_client._authenticator == SnowflakeAuth.KEY_PAIR

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -199,6 +199,7 @@ def test_client_falls_back_to_external_browser_without_private_key():
     assert snowflake_client._authenticator == SnowflakeAuth.EXTERNAL_BROWSER
     assert snowflake_client._private_key is None
 
+
 def test_key_pair_precedence():
     test_rsa_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 


### PR DESCRIPTION
Partially resolves https://jira.ecco.com/browse/TNT-2050

## Scope

Implemented:
 - added a public fn named `load_private_key` to convert a string into `RSAPrivateKey` (since we use the bare connector sometimes -- see https://github.com/SneaksAndData/airflow-dags/pull/1775/changes)
 - added `SnowflakeAuth` enum
- added tests

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Pylint 10.0/10.0 without bloating `.pylintrc` with exceptions.
- [ ] Review requested on `latest` commit.
