### PR TITLE
Fix handling of 3.10 optional syntax

### DIFF
--- a/adapta/utils/polars.py
+++ b/adapta/utils/polars.py
@@ -6,6 +6,7 @@ from dataclasses import fields, is_dataclass
 from datetime import date, datetime
 from typing import Any, get_args, get_origin
 import typing
+import types
 
 import polars
 
@@ -50,7 +51,7 @@ def get_polars_type(dtype: Any) -> polars.DataType:
         return polars.Struct({f.name: get_polars_type(f.type) for f in fields(dtype)})
 
     # Handle fields wrapped in Optional
-    if get_origin(dtype) == typing.Union:
+    if get_origin(dtype) in (typing.Union, types.UnionType):
         return get_polars_type(get_args(dtype)[0])
 
     if get_origin(dtype) == list:

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -15,6 +15,8 @@ def test_polars_schema():
         value_datetime: datetime
         value_date: date
         value_float: float
+        value_optional: Optional[datetime]
+        value_optional_none: datetime | None = None
 
     assert get_polars_schema(Test) == {
         "value_int": polars.Int64,
@@ -23,6 +25,8 @@ def test_polars_schema():
         "value_datetime": polars.Datetime,
         "value_date": polars.Date,
         "value_float": polars.Float64,
+        "value_optional": polars.Datetime,
+        "value_optional_none": polars.Datetime,
     }
 
 


### PR DESCRIPTION
Running the `get_schema` of a `value_optional_none: datetime | None = None` field currently returns a `KeyError: datetime.datetime | None` since it doesn't recognizes it as a union type and never does the unpack