### PR TITLE
Add delete filter / partial overwrite

### DIFF
--- a/adapta/storage/iceberg/v1/_functions.py
+++ b/adapta/storage/iceberg/v1/_functions.py
@@ -184,7 +184,7 @@ def write_using_catalog(
     with target_table.transaction() as write_tx:
         if overwrite:
             write_tx.delete(delete_filter=ALWAYS_TRUE)
-        if delete_filter_expression:    
+        if delete_filter_expression:
             write_tx.delete(delete_filter=delete_filter_expression)
         iterator = (
             data.iter_slices(n_rows=write_chunk_size)

--- a/adapta/storage/iceberg/v1/_functions.py
+++ b/adapta/storage/iceberg/v1/_functions.py
@@ -182,8 +182,10 @@ def write_using_catalog(
     delete_filter_expression = compile_expression(delete_filter, IcebergFilterExpression) if delete_filter else None
 
     with target_table.transaction() as write_tx:
-        if overwrite or delete_filter_expression:
-            write_tx.delete(delete_filter=delete_filter_expression or ALWAYS_TRUE)
+        if overwrite:
+            write_tx.delete(delete_filter=ALWAYS_TRUE)
+        if delete_filter_expression:    
+            write_tx.delete(delete_filter=delete_filter_expression)
         iterator = (
             data.iter_slices(n_rows=write_chunk_size)
             if isinstance(data, polars.DataFrame)

--- a/adapta/storage/iceberg/v1/_functions.py
+++ b/adapta/storage/iceberg/v1/_functions.py
@@ -141,12 +141,14 @@ def write_using_catalog(
     data: polars.DataFrame | polars.LazyFrame,
     write_chunk_size: int = 50_000,
     overwrite: bool = True,
-    merge_columns: list[str] = None,
+    merge_columns: list[str] | None = None,
+    delete_filter: Expression | None = None,
 ) -> None:
     """
     Writes data to an Iceberg table from the provided Metaframe. Will create a table if it doesn't exist.
     Data is written in chunks to regulate memory usage.
     If `merge_columns` is provided an upsert will be performed
+    If `delete_filter` is provided the data matching the filter will be deleted before performing the insert/update
     Note when using S3 compatible storage: if you are getting checksum validation errors, add these two env variables:
         os.environ["AWS_REQUEST_CHECKSUM_CALCULATION"] = "WHEN_REQUIRED"
         os.environ["AWS_RESPONSE_CHECKSUM_VALIDATION"] = "WHEN_REQUIRED"
@@ -177,9 +179,13 @@ def write_using_catalog(
         target_table.io.properties["s3.endpoint"] = os.environ["ADAPTA__ICEBERG_REST_CATALOG__S3_ENDPOINT_OVERRIDE"]
         target_table.config["s3.endpoint"] = os.environ["ADAPTA__ICEBERG_REST_CATALOG__S3_ENDPOINT_OVERRIDE"]
 
+    delete_filter_expression = None
+    if delete_filter:
+        delete_filter_expression = compile_expression(delete_filter, IcebergFilterExpression)
+
     with target_table.transaction() as write_tx:
-        if overwrite:
-            write_tx.delete(delete_filter=ALWAYS_TRUE)
+        if overwrite or delete_filter_expression:
+            write_tx.delete(delete_filter=delete_filter_expression or ALWAYS_TRUE)
         iterator = (
             data.iter_slices(n_rows=write_chunk_size)
             if isinstance(data, polars.DataFrame)

--- a/adapta/storage/iceberg/v1/_functions.py
+++ b/adapta/storage/iceberg/v1/_functions.py
@@ -179,9 +179,7 @@ def write_using_catalog(
         target_table.io.properties["s3.endpoint"] = os.environ["ADAPTA__ICEBERG_REST_CATALOG__S3_ENDPOINT_OVERRIDE"]
         target_table.config["s3.endpoint"] = os.environ["ADAPTA__ICEBERG_REST_CATALOG__S3_ENDPOINT_OVERRIDE"]
 
-    delete_filter_expression = None
-    if delete_filter:
-        delete_filter_expression = compile_expression(delete_filter, IcebergFilterExpression)
+    delete_filter_expression = compile_expression(delete_filter, IcebergFilterExpression) if delete_filter else None
 
     with target_table.transaction() as write_tx:
         if overwrite or delete_filter_expression:

--- a/adapta/storage/query_enabled_store/_models.py
+++ b/adapta/storage/query_enabled_store/_models.py
@@ -1,5 +1,5 @@
 """
- Query Enabled Store Connection interface.
+Query Enabled Store Connection interface.
 """
 
 #  Copyright (c) 2023-2026. ECCO Data & AI and other project contributors.
@@ -132,7 +132,15 @@ class QueryEnabledStore(Generic[TCredential, TSettings], ABC):
         """
 
     @abstractmethod
-    def _write(self, path: DataPath, data: MetaFrame | Iterator[MetaFrame], block_size: int, overwrite: bool) -> None:
+    def _write(
+        self,
+        path: DataPath,
+        data: MetaFrame | Iterator[MetaFrame],
+        block_size: int,
+        overwrite: bool,
+        merge_columns: list[str] | None = None,
+        delete_filter: Expression | None = None,
+    ) -> None:
         """
         Writes `data` to the provided path, using the underlying store implementation.
         """

--- a/adapta/storage/query_enabled_store/_qes_astra.py
+++ b/adapta/storage/query_enabled_store/_qes_astra.py
@@ -1,6 +1,7 @@
 """
- QES implementations for DataStax Astra.
+QES implementations for DataStax Astra.
 """
+
 import os
 import re
 from dataclasses import dataclass
@@ -66,7 +67,15 @@ class AstraQueryEnabledStore(QueryEnabledStore[AstraCredential, AstraSettings]):
     QES Client for Astra DB (Cassandra).
     """
 
-    def _write(self, path: DataPath, data: MetaFrame | Iterator[MetaFrame], block_size: int, overwrite: bool) -> None:
+    def _write(
+        self,
+        path: DataPath,
+        data: MetaFrame | Iterator[MetaFrame],
+        block_size: int,
+        overwrite: bool,
+        merge_columns: list[str] | None = None,
+        delete_filter: Expression | None = None,
+    ) -> None:
         raise NotImplementedError("Writing not supported by this QES engine.")
 
     def close(self) -> None:

--- a/adapta/storage/query_enabled_store/_qes_delta.py
+++ b/adapta/storage/query_enabled_store/_qes_delta.py
@@ -1,6 +1,7 @@
 """
- QES implementations for delta-rs.
+QES implementations for delta-rs.
 """
+
 import re
 from dataclasses import dataclass
 from pydoc import locate
@@ -91,5 +92,13 @@ class DeltaQueryEnabledStore(QueryEnabledStore[DeltaCredential, DeltaSettings]):
     def _apply_query(self, query: str) -> MetaFrame | Iterator[MetaFrame]:
         raise NotImplementedError("Text queries are not supported by Delta QES")
 
-    def _write(self, path: DataPath, data: MetaFrame | Iterator[MetaFrame], block_size: int, overwrite: bool) -> None:
+    def _write(
+        self,
+        path: DataPath,
+        data: MetaFrame | Iterator[MetaFrame],
+        block_size: int,
+        overwrite: bool,
+        merge_columns: list[str] | None = None,
+        delete_filter: Expression | None = None,
+    ) -> None:
         raise NotImplementedError("Writing not supported by this QES engine.")

--- a/adapta/storage/query_enabled_store/_qes_iceberg.py
+++ b/adapta/storage/query_enabled_store/_qes_iceberg.py
@@ -1,6 +1,7 @@
 """
- QES implementations for PyIceberg.
+QES implementations for PyIceberg.
 """
+
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -99,7 +100,13 @@ class IcebergQueryEnabledStore(QueryEnabledStore[IcebergCredential, IcebergSetti
         raise NotImplementedError("Text queries are not supported by Iceberg QES")
 
     def _write(
-        self, path: IcebergPath, data: MetaFrame | Iterator[MetaFrame], block_size: int, overwrite: bool
+        self,
+        path: IcebergPath,
+        data: MetaFrame | Iterator[MetaFrame],
+        block_size: int,
+        overwrite: bool,
+        merge_columns: list[str] | None = None,
+        delete_filter: Expression | None = None,
     ) -> None:
         # only polars is supported
         def _resolve_dataframe() -> DataFrame | LazyFrame:
@@ -117,4 +124,6 @@ class IcebergQueryEnabledStore(QueryEnabledStore[IcebergCredential, IcebergSetti
             data=_resolve_dataframe(),
             write_chunk_size=block_size,
             overwrite=overwrite,
+            merge_columns=merge_columns,
+            delete_filter=delete_filter,
         )

--- a/adapta/storage/query_enabled_store/_qes_local.py
+++ b/adapta/storage/query_enabled_store/_qes_local.py
@@ -1,4 +1,5 @@
 """Local Query Enabled Store (QES) for reading local files."""
+
 import os.path
 import re
 from collections.abc import Iterator
@@ -83,7 +84,15 @@ class LocalQueryEnabledStore(QueryEnabledStore[LocalCredential, LocalSettings]):
         """
         raise NotImplementedError("Text queries are currently not supported by Local QES")
 
-    def _write(self, path: LocalPath, data: MetaFrame | Iterator[MetaFrame], block_size: int, overwrite: bool) -> None:
+    def _write(
+        self,
+        path: LocalPath,
+        data: MetaFrame | Iterator[MetaFrame],
+        block_size: int,
+        overwrite: bool,
+        merge_columns: list[str] | None = None,
+        delete_filter: Expression | None = None,
+    ) -> None:
         if isinstance(data, Iterator):
             for ix, metaframe in enumerate(data):
                 with open(os.path.join(path.path, f"_{ix}"), "wb") as f:

--- a/adapta/storage/query_enabled_store/_qes_trino.py
+++ b/adapta/storage/query_enabled_store/_qes_trino.py
@@ -1,6 +1,7 @@
 """
- QES implementations for Trino.
+QES implementations for Trino.
 """
+
 import os
 import re
 from dataclasses import dataclass
@@ -142,5 +143,13 @@ class TrinoQueryEnabledStore(QueryEnabledStore[TrinoCredential, TrinoSettings]):
 
         return query
 
-    def _write(self, path: TrinoPath, data: MetaFrame | Iterator[MetaFrame], block_size: int, overwrite: bool) -> None:
+    def _write(
+        self,
+        path: TrinoPath,
+        data: MetaFrame | Iterator[MetaFrame],
+        block_size: int,
+        overwrite: bool,
+        merge_columns: list[str] | None = None,
+        delete_filter: Expression | None = None,
+    ) -> None:
         raise NotImplementedError("Writing not supported by this QES engine.")

--- a/tests/iceberg_clients/test_iceberg.py
+++ b/tests/iceberg_clients/test_iceberg.py
@@ -66,21 +66,27 @@ def test_map_read(trino_test_connection: sqlalchemy.engine.Engine, iceberg_catal
     expected_pl = polars.DataFrame(input_data, schema=schema)
 
     with trino_test_connection.connect() as con:
-        con.execute(text("""
+        con.execute(
+            text(
+                """
         CREATE OR REPLACE TABLE test.test_map_read (
             cola integer,
             colb varchar,
             colc array(integer),
             cold map(varchar(10), double)
-        )"""))
+        )"""
+            )
+        )
         for ix_row in range(len(input_data["cola"])):
             array_value = ", ".join([str(v) for v in input_data["colc"][ix_row]])
             map_keys_value = ", ".join([f"'{v['key']}'" for v in input_data["cold"][ix_row]])
             map_values_value = ", ".join([str(v["value"]) for v in input_data["cold"][ix_row]])
-            query = text(f"""
+            query = text(
+                f"""
                          INSERT INTO test.test_map_read (cola, colb, colc, cold)
                          VALUES ({input_data['cola'][ix_row]}, '{input_data['colb'][ix_row]}', ARRAY[{array_value}], MAP(ARRAY[{map_keys_value}], cast(ARRAY[{map_values_value}] as array(double))))
-                         """)
+                         """
+            )
             con.execute(query)
 
     data = load_using_catalog(

--- a/tests/iceberg_clients/test_iceberg.py
+++ b/tests/iceberg_clients/test_iceberg.py
@@ -66,27 +66,21 @@ def test_map_read(trino_test_connection: sqlalchemy.engine.Engine, iceberg_catal
     expected_pl = polars.DataFrame(input_data, schema=schema)
 
     with trino_test_connection.connect() as con:
-        con.execute(
-            text(
-                """
+        con.execute(text("""
         CREATE OR REPLACE TABLE test.test_map_read (
             cola integer,
             colb varchar,
             colc array(integer),
             cold map(varchar(10), double)
-        )"""
-            )
-        )
+        )"""))
         for ix_row in range(len(input_data["cola"])):
             array_value = ", ".join([str(v) for v in input_data["colc"][ix_row]])
             map_keys_value = ", ".join([f"'{v['key']}'" for v in input_data["cold"][ix_row]])
             map_values_value = ", ".join([str(v["value"]) for v in input_data["cold"][ix_row]])
-            query = text(
-                f"""
+            query = text(f"""
                          INSERT INTO test.test_map_read (cola, colb, colc, cold)
                          VALUES ({input_data['cola'][ix_row]}, '{input_data['colb'][ix_row]}', ARRAY[{array_value}], MAP(ARRAY[{map_keys_value}], cast(ARRAY[{map_values_value}] as array(double))))
-                         """
-            )
+                         """)
             con.execute(query)
 
     data = load_using_catalog(
@@ -293,7 +287,7 @@ def test_partial_overwrite_table(iceberg_catalog: Catalog, lazy: bool):
         table_name=table_name,
         catalog=iceberg_catalog,
         data=data2_to_write,
-        overwrite=True,
+        overwrite=False,
         delete_filter=FilterField("cola") == 1,
     )
 

--- a/tests/iceberg_clients/test_iceberg.py
+++ b/tests/iceberg_clients/test_iceberg.py
@@ -8,6 +8,7 @@ from pyiceberg.catalog import Catalog
 from sqlalchemy import text
 
 from adapta.storage.iceberg.v1 import load_using_catalog, write_using_catalog
+from adapta.storage.models.expression_dsl.filter_expression import FilterField
 from tests.iceberg_clients._functions import prepare_iceberg_table, get_input_data, generate_random_string
 
 
@@ -249,6 +250,58 @@ def test_upsert_to_table(iceberg_catalog: Catalog, lazy: bool):
             "cola": [1, 2, 3],
             "colb": ["aa", "b", "c"],
             "colc": [[11], [2], [3]],
+        }
+    )
+
+    read_data = load_using_catalog(
+        schema="test",
+        table_name=table_name,
+        catalog=iceberg_catalog,
+    )
+    assert_frame_equal(read_data.to_polars().sort("cola"), expected_df.sort("cola"), check_column_order=False)
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_partial_overwrite_table(iceberg_catalog: Catalog, lazy: bool):
+    table_name = f"test_partial_overwrite_table_{generate_random_string(8)}".lower()
+    input_data1 = {
+        "cola": [1, 1, 2],
+        "colb": ["a", "1", "c"],
+        "colc": [[1], [1], [3]],
+    }
+    df1 = polars.DataFrame(input_data1)
+    data1_to_write = df1.lazy() if lazy else df1
+
+    write_using_catalog(
+        schema_name="test",
+        table_name=table_name,
+        catalog=iceberg_catalog,
+        data=data1_to_write,
+        overwrite=True,
+    )
+
+    input_data2 = {
+        "cola": [1, 3],
+        "colb": ["aa", "d"],
+        "colc": [[11], [4]],
+    }
+    df2 = polars.DataFrame(input_data2)
+    data2_to_write = df2.lazy() if lazy else df2
+
+    write_using_catalog(
+        schema_name="test",
+        table_name=table_name,
+        catalog=iceberg_catalog,
+        data=data2_to_write,
+        overwrite=True,
+        delete_filter=FilterField("cola") == 1,
+    )
+
+    expected_df = polars.DataFrame(
+        {
+            "cola": [1, 2, 3],
+            "colb": ["aa", "c", "d"],
+            "colc": [[11], [3], [4]],
         }
     )
 


### PR DESCRIPTION
`write_tx.delete` supports adding a filter.
Currently we just remove everything, when doing overwrite mode.
However, it would be interesting to support adding a specific filter here.
This could be useful for cases when we would like to do partial overwrite, e.g delete all data for a given key before inserting new data.